### PR TITLE
Use dedicated SceneKey types.

### DIFF
--- a/bravo-android/bravo-android-tests/src/main/java/com/nhaarman/bravo/android/tests/BravoViewTestRule.kt
+++ b/bravo-android/bravo-android-tests/src/main/java/com/nhaarman/bravo/android/tests/BravoViewTestRule.kt
@@ -3,10 +3,11 @@ package com.nhaarman.bravo.android.tests
 import android.support.test.rule.ActivityTestRule
 import com.nhaarman.bravo.android.transition.ViewFactory
 import com.nhaarman.bravo.presentation.Container
+import com.nhaarman.bravo.presentation.SceneKey
 
 class BravoViewTestRule<C : Container>(
     private val viewFactory: ViewFactory,
-    private val sceneKey: String
+    private val sceneKey: SceneKey
 ) : ActivityTestRule<BravoTestActivity>(BravoTestActivity::class.java) {
 
     val viewResult by lazy {

--- a/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/TransitionFactory.kt
+++ b/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/TransitionFactory.kt
@@ -1,6 +1,7 @@
 package com.nhaarman.bravo.android.transition
 
 import com.nhaarman.bravo.presentation.Scene
+import com.nhaarman.bravo.presentation.SceneKey
 
 interface TransitionFactory {
 
@@ -9,7 +10,7 @@ interface TransitionFactory {
 
 class SimpleTransitionFactory(
     private val viewFactory: ViewFactory,
-    private val transitions: Map<Pair<String, String>, Transition>,
+    private val transitions: Map<Pair<SceneKey, SceneKey>, Transition>,
     private val classTransitions: Map<Pair<Class<out Scene<*>>, Class<out Scene<*>>>, Transition>,
     private val classTransitions2: MutableMap<Pair<Class<out Scene<*>>, Class<out Scene<*>>>, (Scene<*>) -> Transition>
 ) : TransitionFactory {
@@ -49,7 +50,7 @@ class TransitionFactoryBuilder internal constructor(
     private val viewFactory: ViewFactory
 ) {
 
-    private val keyTransitions = mutableMapOf<Pair<String, String>, Transition>()
+    private val keyTransitions = mutableMapOf<Pair<SceneKey, SceneKey>, Transition>()
     private val classTransitions = mutableMapOf<Pair<Class<out Scene<*>>, Class<out Scene<*>>>, Transition>()
     private val classTransitions2 =
         mutableMapOf<Pair<Class<out Scene<*>>, Class<out Scene<*>>>, (Scene<*>) -> Transition>()
@@ -63,7 +64,7 @@ class TransitionFactoryBuilder internal constructor(
         classTransitions2 += Pair(this, transition)
     }
 
-    infix fun Pair<String, String>.use(transition: Transition) {
+    infix fun Pair<SceneKey, SceneKey>.use(transition: Transition) {
         keyTransitions += Pair(this, transition)
     }
 

--- a/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/ViewFactory.kt
+++ b/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/ViewFactory.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.nhaarman.bravo.presentation.Container
 import com.nhaarman.bravo.presentation.Scene
+import com.nhaarman.bravo.presentation.SceneKey
 
 /**
  * A factory interface that can create view instances for [Scene]s.
@@ -22,7 +23,7 @@ interface ViewFactory {
      *
      * @return The resulting [ViewResult].
      */
-    fun viewFor(sceneKey: String, parent: ViewGroup): ViewResult
+    fun viewFor(sceneKey: SceneKey, parent: ViewGroup): ViewResult
 }
 
 /**

--- a/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/ViewFactoryDSL.kt
+++ b/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/ViewFactoryDSL.kt
@@ -10,6 +10,7 @@ import com.nhaarman.bravo.android.util.inflate
 import com.nhaarman.bravo.android.util.inflateView
 import com.nhaarman.bravo.presentation.Container
 import com.nhaarman.bravo.presentation.Scene
+import com.nhaarman.bravo.presentation.SceneKey
 
 /**
  * An entry point for the [ViewFactory] DSL.
@@ -26,7 +27,7 @@ fun bindViews(init: ViewFactoryBuilder.() -> Unit): ViewFactory {
  */
 class ViewFactoryBuilder internal constructor() {
 
-    private val bindings = mutableMapOf<String, Binding>()
+    private val bindings = mutableMapOf<SceneKey, Binding>()
 
     /**
      * Binds [Scene]s with given [sceneKey] to the layout with given
@@ -37,7 +38,7 @@ class ViewFactoryBuilder internal constructor() {
      *                    [Scene]. The root view of the inflated layout must
      *                    implement the [Container] contract for the [Scene].
      */
-    fun bind(sceneKey: String, @LayoutRes layoutResId: Int) {
+    fun bind(sceneKey: SceneKey, @LayoutRes layoutResId: Int) {
         bindings[sceneKey] = ViewResourceBinding(layoutResId)
     }
 
@@ -52,7 +53,7 @@ class ViewFactoryBuilder internal constructor() {
      * @param wrapper A function that takes in the inflated layout and returns
      *                a [Container] instance that can be passed to the [Scene].
      */
-    fun bind(sceneKey: String, @LayoutRes layoutResId: Int, wrapper: (View) -> Container) {
+    fun bind(sceneKey: SceneKey, @LayoutRes layoutResId: Int, wrapper: (View) -> Container) {
         bindings[sceneKey] = WrappedViewResourceBinding(layoutResId, wrapper)
     }
 
@@ -68,7 +69,7 @@ class ViewFactoryBuilder internal constructor() {
      *                [ViewGroup] and returns a [Container] instance that can be
      *                passed to the [Scene].
      */
-    fun bindViewGroup(sceneKey: String, @LayoutRes layoutResId: Int, wrapper: (ViewGroup) -> Container) {
+    fun bindViewGroup(sceneKey: SceneKey, @LayoutRes layoutResId: Int, wrapper: (ViewGroup) -> Container) {
         bindings[sceneKey] = WrappedViewGroupResourceBinding(layoutResId, wrapper)
     }
 
@@ -79,13 +80,13 @@ class ViewFactoryBuilder internal constructor() {
 }
 
 internal class DefaultViewFactory(
-    private val bindings: Map<String, Binding>
+    private val bindings: Map<SceneKey, Binding>
 ) : ViewFactory {
 
-    override fun viewFor(sceneKey: String, parent: ViewGroup): ViewResult {
+    override fun viewFor(sceneKey: SceneKey, parent: ViewGroup): ViewResult {
         return bindings[sceneKey]
             ?.create(parent)
-            ?: error("Unable to create view for Scene with key: \"${sceneKey}\".")
+            ?: error("Unable to create view for Scene with key: \"$sceneKey\".")
     }
 }
 

--- a/bravo-core/src/main/java/com/nhaarman/bravo/presentation/Scene.kt
+++ b/bravo-core/src/main/java/com/nhaarman/bravo/presentation/Scene.kt
@@ -1,5 +1,7 @@
 package com.nhaarman.bravo.presentation
 
+import com.nhaarman.bravo.presentation.SceneKey.Companion.from
+
 /**
  * A Scene is a destination in the application the user can navigate to.
  *
@@ -33,7 +35,7 @@ interface Scene<V : Container> {
      * This key can be used to determine what layout to show, and can be used
      * to save and restore instance state, if needed.
      */
-    val key: String get() = this.javaClass.name
+    val key: SceneKey get() = SceneKey.from(javaClass)
 
     /**
      * Called when this Scene becomes active.

--- a/bravo-core/src/main/java/com/nhaarman/bravo/presentation/SceneKey.kt
+++ b/bravo-core/src/main/java/com/nhaarman/bravo/presentation/SceneKey.kt
@@ -1,0 +1,59 @@
+package com.nhaarman.bravo.presentation
+
+import kotlin.reflect.KClass
+
+/**
+ * A class representing the key for a Scene.
+ */
+class SceneKey(val value: String) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SceneKey
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    override fun toString(): String {
+        return "SceneKey(value='$value')"
+    }
+
+    companion object {
+
+        /**
+         * Create a [SceneKey] for given [Scene] class, consisting of its fully
+         * qualified name.
+         */
+        fun <T : Scene<*>> from(sceneClass: KClass<T>): SceneKey {
+            return SceneKey.from(sceneClass.java)
+        }
+
+        /**
+         * Create a [SceneKey] for given [Scene] class, consisting of its fully
+         * qualified name.
+         */
+        fun <T : Scene<*>> from(sceneClass: Class<T>): SceneKey {
+            return SceneKey(sceneClass.name)
+        }
+
+        /**
+         * Returns the default [SceneKey] for [T], consisting of its fully
+         * qualified class name.
+         */
+        inline fun <reified T : Scene<*>> T.defaultKey(): SceneKey {
+            return SceneKey.from(T::class)
+        }
+
+        inline fun <reified T : Scene<*>> defaultKey(): SceneKey {
+            return from(T::class)
+        }
+    }
+}

--- a/notes-app/bravo/android/src/androidTest/java/com/nhaarman/bravo/notesapp/android/ui/createitem/CreateItemViewTest.kt
+++ b/notes-app/bravo/android/src/androidTest/java/com/nhaarman/bravo/notesapp/android/ui/createitem/CreateItemViewTest.kt
@@ -44,7 +44,7 @@ class CreateItemViewTest {
         onView(withHint("Take a note")).perform(typeText("Hello, world!"))
 
         /* Then */
-        expect(observer.lastValue).toBe("Hello, world!")
+        expect(observer.lastValue.trim()).toBe("Hello, world!")
     }
 
     @Test

--- a/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/presentation/createitem/CreateItemScene.kt
+++ b/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/presentation/createitem/CreateItemScene.kt
@@ -5,6 +5,7 @@ import com.nhaarman.bravo.notesapp.mainThread
 import com.nhaarman.bravo.notesapp.note.NoteItem
 import com.nhaarman.bravo.notesapp.note.NoteItemsRepository
 import com.nhaarman.bravo.presentation.RxScene
+import com.nhaarman.bravo.presentation.SceneKey.Companion.defaultKey
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.plusAssign
 import io.reactivex.rxkotlin.withLatestFrom
@@ -15,8 +16,6 @@ class CreateItemScene(
     private val listener: Events,
     savedState: SceneState? = null
 ) : RxScene<CreateItemContainer>(savedState) {
-
-    override val key = CreateItemScene.key
 
     private val textObservable by lazy {
         Observable.just(initialText ?: "")
@@ -51,6 +50,6 @@ class CreateItemScene(
 
     companion object {
 
-        val key = CreateItemScene::class.java.name
+        val key = defaultKey<CreateItemScene>()
     }
 }

--- a/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/presentation/edititem/EditItemScene.kt
+++ b/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/presentation/edititem/EditItemScene.kt
@@ -4,6 +4,7 @@ import com.nhaarman.bravo.SceneState
 import com.nhaarman.bravo.notesapp.mainThread
 import com.nhaarman.bravo.notesapp.note.NoteItemsRepository
 import com.nhaarman.bravo.presentation.RxScene
+import com.nhaarman.bravo.presentation.SceneKey.Companion.defaultKey
 import io.reactivex.rxkotlin.plusAssign
 
 class EditItemScene(
@@ -12,8 +13,6 @@ class EditItemScene(
     private val listener: Events,
     savedState: SceneState? = null
 ) : RxScene<EditItemContainer>(savedState) {
-
-    override val key = EditItemScene.key
 
     private val originalItem by lazy {
         noteItemsRepository.find(itemId)
@@ -62,7 +61,7 @@ class EditItemScene(
 
     companion object {
 
-        val key: String = EditItemScene::class.java.name
+        val key = defaultKey<EditItemScene>()
 
         fun create(
             noteItemsRepository: NoteItemsRepository,

--- a/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/presentation/itemlist/ItemListScene.kt
+++ b/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/presentation/itemlist/ItemListScene.kt
@@ -5,6 +5,7 @@ import com.nhaarman.bravo.notesapp.mainThread
 import com.nhaarman.bravo.notesapp.note.NoteItem
 import com.nhaarman.bravo.notesapp.note.NoteItemsRepository
 import com.nhaarman.bravo.presentation.RxScene
+import com.nhaarman.bravo.presentation.SceneKey.Companion.defaultKey
 import io.reactivex.rxkotlin.plusAssign
 
 class ItemListScene(
@@ -51,10 +52,8 @@ class ItemListScene(
         fun showItemRequested(item: NoteItem)
     }
 
-    override val key: String = ItemListScene.key
-
     companion object {
 
-        val key: String = ItemListScene::class.java.name
+        val key = defaultKey<ItemListScene>()
     }
 }

--- a/samples/hello-navigation/src/main/java/com/nhaarman/bravo/samples/hellonavigation/FirstScene.kt
+++ b/samples/hello-navigation/src/main/java/com/nhaarman/bravo/samples/hellonavigation/FirstScene.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.widget.FrameLayout
 import com.nhaarman.bravo.presentation.Container
 import com.nhaarman.bravo.presentation.Scene
+import com.nhaarman.bravo.samples.hellonavigation.FirstScene.Events
 import kotlinx.android.synthetic.main.first_scene.view.*
 
 /**
@@ -23,8 +24,6 @@ class FirstScene(
     private val listener: Events
 ) : Scene<FirstSceneContainer> {
 
-    override val key = Companion.key
-
     override fun attach(v: FirstSceneContainer) {
         v.onSecondSceneClicked { listener.secondSceneRequested() }
     }
@@ -35,11 +34,6 @@ class FirstScene(
     interface Events {
 
         fun secondSceneRequested()
-    }
-
-    companion object {
-
-        val key = FirstScene::class.java.name
     }
 }
 

--- a/samples/hello-navigation/src/main/java/com/nhaarman/bravo/samples/hellonavigation/MainActivity.kt
+++ b/samples/hello-navigation/src/main/java/com/nhaarman/bravo/samples/hellonavigation/MainActivity.kt
@@ -5,13 +5,14 @@ import android.support.v7.app.AppCompatActivity
 import com.nhaarman.bravo.android.BravoActivityDelegate
 import com.nhaarman.bravo.android.transition.DefaultTransitionFactory
 import com.nhaarman.bravo.android.transition.bindViews
+import com.nhaarman.bravo.presentation.SceneKey.Companion.defaultKey
 
 class MainActivity : AppCompatActivity() {
 
     private val delegate by lazy {
         val viewFactory = bindViews {
-            bind(FirstScene.key, R.layout.first_scene)
-            bind(SecondScene.key, R.layout.second_scene)
+            bind(defaultKey<FirstScene>(), R.layout.first_scene)
+            bind(defaultKey<SecondScene>(), R.layout.second_scene)
         }
 
         BravoActivityDelegate(

--- a/samples/hello-navigation/src/main/java/com/nhaarman/bravo/samples/hellonavigation/SecondScene.kt
+++ b/samples/hello-navigation/src/main/java/com/nhaarman/bravo/samples/hellonavigation/SecondScene.kt
@@ -11,8 +11,6 @@ class SecondScene(
     private val listener: Events
 ) : Scene<SecondSceneContainer> {
 
-    override val key = Companion.key
-
     override fun attach(v: SecondSceneContainer) {
         v.onFirstSceneClicked { listener.onFirstSceneRequested() }
     }
@@ -20,11 +18,6 @@ class SecondScene(
     interface Events {
 
         fun onFirstSceneRequested()
-    }
-
-    companion object {
-
-        val key = SecondScene::class.java.name
     }
 }
 

--- a/samples/hello-world/src/main/java/com/nhaarman/bravo/samples/helloworld/HelloWorldScene.kt
+++ b/samples/hello-world/src/main/java/com/nhaarman/bravo/samples/helloworld/HelloWorldScene.kt
@@ -4,14 +4,7 @@ import com.nhaarman.bravo.presentation.Scene
 
 class HelloWorldScene : Scene<HelloWorldContainer> {
 
-    override val key = HelloWorldScene.key
-
     override fun attach(v: HelloWorldContainer) {
         v.text = "Hello, world!"
-    }
-
-    companion object {
-
-        val key = HelloWorldScene::class.java.name
     }
 }

--- a/samples/hello-world/src/main/java/com/nhaarman/bravo/samples/helloworld/MainActivity.kt
+++ b/samples/hello-world/src/main/java/com/nhaarman/bravo/samples/helloworld/MainActivity.kt
@@ -5,12 +5,13 @@ import android.os.Bundle
 import com.nhaarman.bravo.android.BravoActivityDelegate
 import com.nhaarman.bravo.android.transition.DefaultTransitionFactory
 import com.nhaarman.bravo.android.transition.bindViews
+import com.nhaarman.bravo.presentation.SceneKey.Companion.defaultKey
 
 class MainActivity : Activity() {
 
     private val delegate by lazy {
         val viewFactory = bindViews {
-            bind(HelloWorldScene.key, R.layout.hello_world)
+            bind(defaultKey<HelloWorldScene>(), R.layout.hello_world)
         }
 
         BravoActivityDelegate(

--- a/samples/notes-app
+++ b/samples/notes-app
@@ -1,1 +1,0 @@
-../notes-app/bravo


### PR DESCRIPTION
This adds a little more type safety, and may prevent some easy mistakes
from slipping in:

```kotlin
class MyScene : Scene<Container> {

  companion object {
    val key = MyScene::class.java
  }
}
```

The above may work initially, but whenever the default key definition
changes, things break.