### PR TITLE
Decouple Navigator events from its results

### DIFF
--- a/core/bravo-core/src/main/java/com/nhaarman/bravo/navigation/Navigator.kt
+++ b/core/bravo-core/src/main/java/com/nhaarman/bravo/navigation/Navigator.kt
@@ -27,7 +27,7 @@ import com.nhaarman.bravo.presentation.Scene
  *
  * The Navigator is a class that takes care of navigating the user through an
  * application by showing a sequence of Scenes.
- * Interested parties may subscribe a listener using [addListener], through which
+ * Interested parties may subscribe a listener using [addNavigatorEventsListener], through which
  * Scene changes will be published.
  *
  * Navigators are responsible for handling the lifecycles of the Scenes they
@@ -53,7 +53,7 @@ import com.nhaarman.bravo.presentation.Scene
  * can be saved. When this is the case, [SaveableNavigator.saveInstanceState] will
  * be called at the appropriate time.
  */
-interface Navigator<E : Navigator.Events> {
+interface Navigator {
 
     /**
      * Registers given [listener] with this Navigator.
@@ -62,7 +62,7 @@ interface Navigator<E : Navigator.Events> {
      * [listener] is not interested in events anymore.
      */
     @CheckResult
-    fun addListener(listener: E): DisposableHandle
+    fun addNavigatorEventsListener(listener: Navigator.Events): DisposableHandle
 
     /**
      * Starts this Navigator.
@@ -70,7 +70,7 @@ interface Navigator<E : Navigator.Events> {
      * Calling this method when the Navigator is not started or destroyed triggers
      * a call to [Scene.onStart] for the [Scene] that is currently active in the
      * Navigator.
-     * Listeners registered with [addListener] will be notified of that Scene
+     * Listeners registered with [addNavigatorEventsListener] will be notified of that Scene
      * through [Events.scene].
      *
      * Calling this method when the Navigator is started or destroyed has no effect.

--- a/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/BravoActivityDelegate.kt
+++ b/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/BravoActivityDelegate.kt
@@ -54,7 +54,7 @@ class BravoActivityDelegate private constructor(
     private val sceneTransformer: SceneTransformer = DefaultSceneTransformer(intentProvider)
 ) {
 
-    private lateinit var navigator: Navigator<Navigator.Events>
+    private lateinit var navigator: Navigator
 
     private var state by lazyVar {
         ViewState.create(activity.root, viewFactory, transitionFactory)
@@ -80,9 +80,9 @@ class BravoActivityDelegate private constructor(
     fun onCreate(savedInstanceState: Bundle?) {
         lastExternalSceneClass = savedInstanceState.lastExternalSceneClass
 
-        navigator = navigatorProvider.navigatorFor(savedInstanceState.navigatorState) as Navigator<Navigator.Events>
+        navigator = navigatorProvider.navigatorFor(savedInstanceState.navigatorState)
 
-        disposable = navigator.addListener(sceneDispatcher)
+        disposable = navigator.addNavigatorEventsListener(sceneDispatcher)
     }
 
     fun onStart() {

--- a/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/navigation/AbstractNavigatorProvider.kt
+++ b/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/navigation/AbstractNavigatorProvider.kt
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit
  * saved Navigator state. This means that if the saved state is older than 30
  * minutes, the state is dropped and a fresh instance is created.
  */
-abstract class AbstractNavigatorProvider<N : Navigator<out Navigator.Events>> : NavigatorProvider {
+abstract class AbstractNavigatorProvider<N : Navigator> : NavigatorProvider {
 
     private var navigator: N? = null
 

--- a/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/navigation/NavigatorProvider.kt
+++ b/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/navigation/NavigatorProvider.kt
@@ -38,7 +38,7 @@ interface NavigatorProvider {
      * @param savedState If not null, the saved state for the Navigator as returned
      * by [saveNavigatorState].
      */
-    fun navigatorFor(savedState: NavigatorState?): Navigator<*>
+    fun navigatorFor(savedState: NavigatorState?): Navigator
 
     /**
      * Returns the saved state for the [Navigator] as returned by [navigatorFor].

--- a/ext/bravo-android/src/test/java/com/nhaarman/bravo/android/navigation/AbstractNavigatorProviderTest.kt
+++ b/ext/bravo-android/src/test/java/com/nhaarman/bravo/android/navigation/AbstractNavigatorProviderTest.kt
@@ -18,7 +18,6 @@
 
 package com.nhaarman.bravo.android.navigation
 
-import com.nhaarman.bravo.navigation.Navigator
 import com.nhaarman.bravo.navigation.SingleSceneNavigator
 import com.nhaarman.bravo.presentation.Container
 import com.nhaarman.bravo.presentation.Scene
@@ -55,7 +54,7 @@ internal class AbstractNavigatorProviderTest {
         expect(result1).toNotBeTheSameAs(result2)
     }
 
-    private class TestNavigator : SingleSceneNavigator<Navigator.Events>(null) {
+    private class TestNavigator : SingleSceneNavigator(null) {
 
         override fun createScene(state: SceneState?): Scene<out Container> {
             return mock()

--- a/ext/bravo/bravo-testing/src/main/java/com/nhaarman/bravo/testing/TestContext.kt
+++ b/ext/bravo/bravo-testing/src/main/java/com/nhaarman/bravo/testing/TestContext.kt
@@ -30,7 +30,7 @@ import com.nhaarman.bravo.presentation.Scene
  * A class that provides simple Scene/Container management for tests.
  */
 class TestContext private constructor(
-    private val navigator: Navigator<Navigator.Events>,
+    private val navigator: Navigator,
     private val containerProvider: ContainerProvider
 ) : Navigator.Events {
 
@@ -39,7 +39,7 @@ class TestContext private constructor(
     fun <T> container(): T = container as T
 
     init {
-        navigator.addListener(this)
+        navigator.addNavigatorEventsListener(this)
         navigator.onStart()
     }
 
@@ -60,8 +60,8 @@ class TestContext private constructor(
 
     companion object {
 
-        fun create(navigator: Navigator<*>, containerProvider: ContainerProvider): TestContext {
-            return TestContext(navigator as Navigator<Navigator.Events>, containerProvider)
+        fun create(navigator: Navigator, containerProvider: ContainerProvider): TestContext {
+            return TestContext(navigator as Navigator, containerProvider)
         }
     }
 }

--- a/ext/bravo/src/main/java/com/nhaarman/bravo/navigation/SingleSceneNavigator.kt
+++ b/ext/bravo/src/main/java/com/nhaarman/bravo/navigation/SingleSceneNavigator.kt
@@ -40,9 +40,9 @@ import com.nhaarman.bravo.util.lazyVar
  * @param savedState An optional instance that contains saved state as returned
  *                   by [saveInstanceState].
  */
-abstract class SingleSceneNavigator<Events : Navigator.Events>(
+abstract class SingleSceneNavigator(
     private val savedState: NavigatorState?
-) : Navigator<Events>, SaveableNavigator, OnBackPressListener {
+) : Navigator, SaveableNavigator, OnBackPressListener {
 
     /**
      * Creates the [Scene] instance to host.
@@ -50,16 +50,16 @@ abstract class SingleSceneNavigator<Events : Navigator.Events>(
      * @param state An optional saved state instance to restore the Scene's
      *              state from.
      */
-    abstract fun createScene(state: SceneState?): Scene<out Container>
+    protected abstract fun createScene(state: SceneState?): Scene<out Container>
 
     private val scene by lazy { createScene(savedState?.sceneState) }
 
     private var state by lazyVar { LifecycleState.create(scene) }
 
-    protected val listeners = mutableListOf<Events>()
+    private var listeners = listOf<Navigator.Events>()
 
     @CallSuper
-    override fun addListener(listener: Events): DisposableHandle {
+    override fun addNavigatorEventsListener(listener: Navigator.Events): DisposableHandle {
         listeners += listener
 
         if (state is LifecycleState.Active) {

--- a/ext/bravo/src/main/java/com/nhaarman/bravo/navigation/StackNavigator.kt
+++ b/ext/bravo/src/main/java/com/nhaarman/bravo/navigation/StackNavigator.kt
@@ -43,9 +43,9 @@ import com.nhaarman.bravo.util.lazyVar
  * @param savedState An optional instance that contains saved state as returned
  *                   by this class's saveInstanceState() method.
  */
-abstract class StackNavigator<E : Navigator.Events>(
+abstract class StackNavigator(
     private val savedState: NavigatorState?
-) : Navigator<E>, SaveableNavigator, OnBackPressListener {
+) : Navigator, SaveableNavigator, OnBackPressListener {
 
     /**
      * Creates the initial stack of [Scene]s for this StackNavigator.
@@ -61,10 +61,13 @@ abstract class StackNavigator<E : Navigator.Events>(
      *
      * @param sceneClass The class of the [Scene] to instantiate.
      * @param state The saved state of the [Scene] if applicable. This will be
-     *              the instance as returned from [StateSaveable.saveInstanceState]
-     *              if its state was saved.
+     * the instance as returned from [SaveableScene.saveInstanceState] if its
+     * state was saved.
      */
-    abstract fun instantiateScene(sceneClass: Class<Scene<*>>, state: SceneState?): Scene<out Container>
+    protected abstract fun instantiateScene(
+        sceneClass: Class<Scene<*>>,
+        state: SceneState?
+    ): Scene<out Container>
 
     private var state by lazyVar {
         @Suppress("UNCHECKED_CAST")
@@ -86,23 +89,14 @@ abstract class StackNavigator<E : Navigator.Events>(
         State.create(initialStack())
     }
 
-    /**
-     * The list of [E] instances that have registered with this Navigator.
-     *
-     * @see addListener
-     */
-    @Suppress("UNCHECKED_CAST")
-    protected val listeners: List<E>
-        get() = state.listeners as List<E>
-
     @CallSuper
-    override fun addListener(listener: E): DisposableHandle {
+    override fun addNavigatorEventsListener(listener: Navigator.Events): DisposableHandle {
         state.addListener(listener)
 
         return object : DisposableHandle {
 
             override fun isDisposed(): Boolean {
-                return listener in listeners
+                return listener in state.listeners
             }
 
             override fun dispose() {

--- a/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/CompositeReplacingNavigatorTest.kt
+++ b/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/CompositeReplacingNavigatorTest.kt
@@ -58,7 +58,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `navigator is not finished`() {
                 /* When */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* Then */
                 verify(listener, never()).finished()
@@ -73,7 +73,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `added listener does not get notified of scene`() {
                 /* When */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* Then */
                 verify(listener, never()).scene(any(), any())
@@ -82,7 +82,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `pushing a navigator does not notify listeners of scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.replace(navigator2)
@@ -94,7 +94,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `onBackPressed notifies listeners of finished`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 val result = navigator.onBackPressed()
@@ -107,7 +107,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `onBackPressed does not notify screen`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 val result = navigator.onBackPressed()
@@ -120,7 +120,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `onBackPressed for replaced navigator does not notify screen`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.replace(navigator2)
 
                 /* When */
@@ -141,7 +141,7 @@ internal class CompositeReplacingNavigatorTest {
                 navigator.onStart()
 
                 /* When */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* Then */
                 verify(listener, never()).finished()
@@ -162,7 +162,7 @@ internal class CompositeReplacingNavigatorTest {
                 navigator.onStart()
 
                 /* When */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* Then */
                 verify(listener).scene(navigator1Scene1, null)
@@ -171,7 +171,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `starting navigator notifies listeners of scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.onStart()
@@ -183,7 +183,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `starting navigator does not finish`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.onStart()
@@ -195,7 +195,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `replacing a navigator notifies listeners of scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onStart()
 
                 /* When */
@@ -208,7 +208,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `start navigator after navigator replaced notifies pushed scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.replace(navigator2)
 
                 /* When */
@@ -222,7 +222,7 @@ internal class CompositeReplacingNavigatorTest {
             fun `onBackPressed for a single scene notifies finished`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 val result = navigator.onBackPressed()
@@ -236,7 +236,7 @@ internal class CompositeReplacingNavigatorTest {
             fun `onBackPressed for a single scene does not notify screen`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 val result = navigator.onBackPressed()
@@ -254,7 +254,7 @@ internal class CompositeReplacingNavigatorTest {
             fun `onBackPressed for multiple navigators notifies proper scenes`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.replace(navigator2)
 
                 /* When */
@@ -274,7 +274,7 @@ internal class CompositeReplacingNavigatorTest {
             fun `forwards from nested navigator is propagated`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.replace(navigator2)
 
                 /* When */
@@ -292,7 +292,7 @@ internal class CompositeReplacingNavigatorTest {
             fun `backwards from nested navigator is propagated`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.replace(navigator2)
                 navigator2.push(navigator2Scene2)
 
@@ -314,7 +314,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `stopping navigator does not finish`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.onStop()
@@ -339,7 +339,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `destroying navigator does not finish`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.onDestroy()
@@ -360,7 +360,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `pushing a scene for destroyed navigator does not notify listeners`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onDestroy()
 
                 /* When */
@@ -373,7 +373,7 @@ internal class CompositeReplacingNavigatorTest {
             @Test
             fun `onBackPressed for replaced Navigator for destroyed navigator does not notify scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onDestroy()
                 navigator.replace(navigator2)
 
@@ -609,7 +609,7 @@ internal class CompositeReplacingNavigatorTest {
             val bundle = navigator.saveInstanceState()
             val restoredNavigator = RestorableTestCompositeReplacingNavigator(navigator1, bundle)
             restoredNavigator.onStart()
-            restoredNavigator.addListener(listener)
+            restoredNavigator.addNavigatorEventsListener(listener)
 
             /* Then */
             argumentCaptor<Scene<out Container>> {
@@ -623,17 +623,17 @@ internal class CompositeReplacingNavigatorTest {
     }
 
     class TestCompositeReplacingNavigator(
-        private val initialNavigator: Navigator<out Navigator.Events>
-    ) : CompositeReplacingNavigator<Navigator.Events>(null) {
+        private val initialNavigator: Navigator
+    ) : CompositeReplacingNavigator(null) {
 
-        override fun initialNavigator(): Navigator<out Navigator.Events> {
+        override fun initialNavigator(): Navigator {
             return initialNavigator
         }
 
         override fun instantiateNavigator(
-            navigatorClass: Class<Navigator<*>>,
+            navigatorClass: Class<Navigator>,
             state: NavigatorState?
-        ): Navigator<out Navigator.Events> {
+        ): Navigator {
             error("Not supported")
         }
     }
@@ -641,7 +641,7 @@ internal class CompositeReplacingNavigatorTest {
     open class TestSingleSceneNavigator(
         private val scene: Scene<out Container>,
         savedState: NavigatorState? = null
-    ) : SingleSceneNavigator<Navigator.Events>(savedState) {
+    ) : SingleSceneNavigator(savedState) {
 
         override fun createScene(state: SceneState?): Scene<out Container> {
             return scene
@@ -651,7 +651,7 @@ internal class CompositeReplacingNavigatorTest {
     open class TestStackNavigator(
         private val initialStack: List<TestScene>,
         savedState: NavigatorState? = null
-    ) : StackNavigator<Navigator.Events>(savedState) {
+    ) : StackNavigator(savedState) {
 
         override fun initialStack(): List<Scene<out Container>> {
             return initialStack
@@ -666,18 +666,18 @@ internal class CompositeReplacingNavigatorTest {
     }
 
     class RestorableTestCompositeReplacingNavigator(
-        private val initialNavigator: Navigator<out Navigator.Events>,
+        private val initialNavigator: Navigator,
         savedState: NavigatorState?
-    ) : CompositeReplacingNavigator<Navigator.Events>(savedState) {
+    ) : CompositeReplacingNavigator(savedState) {
 
-        override fun initialNavigator(): Navigator<out Navigator.Events> {
+        override fun initialNavigator(): Navigator {
             return initialNavigator
         }
 
         override fun instantiateNavigator(
-            navigatorClass: Class<Navigator<*>>,
+            navigatorClass: Class<Navigator>,
             state: NavigatorState?
-        ): Navigator<out Navigator.Events> {
+        ): Navigator {
             return when (navigatorClass) {
                 RestorableTestSingleSceneNavigator::class.java -> RestorableTestSingleSceneNavigator(
                     TestScene(0),
@@ -692,7 +692,7 @@ internal class CompositeReplacingNavigatorTest {
     open class RestorableTestSingleSceneNavigator(
         private val scene: Scene<out Container>,
         savedState: NavigatorState? = null
-    ) : SingleSceneNavigator<Navigator.Events>(savedState) {
+    ) : SingleSceneNavigator(savedState) {
 
         override fun createScene(state: SceneState?): Scene<out Container> {
             return state?.let { TestScene.create(it) } ?: scene

--- a/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/CompositeStackNavigatorTest.kt
+++ b/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/CompositeStackNavigatorTest.kt
@@ -58,7 +58,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `navigator is not finished`() {
                 /* When */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* Then */
                 verify(listener, never()).finished()
@@ -73,7 +73,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `added listener does not get notified of scene`() {
                 /* When */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* Then */
                 verify(listener, never()).scene(any(), any())
@@ -82,7 +82,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `pushing a navigator does not notify listeners of scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.push(navigator2)
@@ -94,7 +94,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `popping the last scene and navigator from the stack notifies listeners of finished`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.pop()
@@ -106,7 +106,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `popping the second to last navigator from the stack does not notify listeners of finished`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.push(navigator2)
 
                 /* When */
@@ -119,7 +119,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `popping the second to last navigator from the navigator does not notify listeners of scenes`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.push(navigator2)
 
                 /* When */
@@ -132,7 +132,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `onBackPressed for a single scene notifies listeners of finished`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 val result = navigator.onBackPressed()
@@ -145,7 +145,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `onBackPressed for a single scene does not notify screen`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 val result = navigator.onBackPressed()
@@ -158,7 +158,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `onBackPressed for multiple navigators does not notify screen`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.push(navigator2)
 
                 /* When */
@@ -179,7 +179,7 @@ internal class CompositeStackNavigatorTest {
                 navigator.onStart()
 
                 /* When */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* Then */
                 verify(listener, never()).finished()
@@ -200,7 +200,7 @@ internal class CompositeStackNavigatorTest {
                 navigator.onStart()
 
                 /* When */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* Then */
                 verify(listener).scene(navigator1Scene1, null)
@@ -209,7 +209,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `starting navigator notifies listeners of scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.onStart()
@@ -221,7 +221,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `starting navigator does not finish`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.onStart()
@@ -233,7 +233,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `pushing a navigator notifies listeners of scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onStart()
 
                 /* When */
@@ -246,7 +246,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `pushing a navigator - scene notification has forward transition data`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onStart()
 
                 /* When */
@@ -263,7 +263,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `start navigator after navigator push notifies pushed scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.push(navigator2)
 
                 /* When */
@@ -276,7 +276,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `popping the last scene and navigator from the navigator notifies listeners of finished`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onStart()
 
                 /* When */
@@ -289,7 +289,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `popping the second to last navigator from the stack does not notify listeners of finished`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onStart()
                 navigator.push(navigator2)
 
@@ -303,7 +303,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `popping the second to last navigator from the stack notifies listeners of proper scenes`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onStart()
                 navigator.push(navigator2)
 
@@ -322,7 +322,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `popping the second to last navigator from the stack scene - notification has backward transition data`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onStart()
                 navigator.push(navigator2)
 
@@ -340,7 +340,7 @@ internal class CompositeStackNavigatorTest {
             fun `onBackPressed for a single scene notifies finished`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 val result = navigator.onBackPressed()
@@ -354,7 +354,7 @@ internal class CompositeStackNavigatorTest {
             fun `onBackPressed for a single scene does not notify screen`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 val result = navigator.onBackPressed()
@@ -372,7 +372,7 @@ internal class CompositeStackNavigatorTest {
             fun `onBackPressed for multiple navigators notifies proper scenes`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.push(navigator2)
 
                 /* When */
@@ -392,7 +392,7 @@ internal class CompositeStackNavigatorTest {
             fun `onBackPressed for multiple navigators - scene notification has backward transition data`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.push(navigator2)
 
                 /* When */
@@ -409,7 +409,7 @@ internal class CompositeStackNavigatorTest {
             fun `forwards from nested navigator is propagated`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.push(navigator2)
 
                 /* When */
@@ -427,7 +427,7 @@ internal class CompositeStackNavigatorTest {
             fun `backwards from nested navigator is propagated`() {
                 /* Given */
                 navigator.onStart()
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.push(navigator2)
                 navigator2.push(navigator2Scene2)
 
@@ -449,7 +449,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `stopping navigator does not finish`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.onStop()
@@ -474,7 +474,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `destroying navigator does not finish`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
 
                 /* When */
                 navigator.onDestroy()
@@ -495,7 +495,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `pushing a scene for destroyed navigator does not notify listeners`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onDestroy()
 
                 /* When */
@@ -508,7 +508,7 @@ internal class CompositeStackNavigatorTest {
             @Test
             fun `popping from multi item stack for destroyed navigator does not notify scene`() {
                 /* Given */
-                navigator.addListener(listener)
+                navigator.addNavigatorEventsListener(listener)
                 navigator.onDestroy()
                 navigator.push(navigator2)
 
@@ -992,7 +992,7 @@ internal class CompositeStackNavigatorTest {
             val bundle = navigator.saveInstanceState()
             val restoredNavigator = RestorableTestCompositeStackNavigator(listOf(navigator1), bundle)
             restoredNavigator.onStart()
-            restoredNavigator.addListener(listener)
+            restoredNavigator.addNavigatorEventsListener(listener)
 
             /* Then */
             argumentCaptor<Scene<out Container>> {
@@ -1016,7 +1016,7 @@ internal class CompositeStackNavigatorTest {
             val bundle = navigator.saveInstanceState()
             val restoredNavigator = RestorableTestCompositeStackNavigator(listOf(navigator1), bundle)
             restoredNavigator.onStart()
-            restoredNavigator.addListener(listener)
+            restoredNavigator.addNavigatorEventsListener(listener)
 
             /* Then */
             argumentCaptor<Scene<out Container>> {
@@ -1042,17 +1042,17 @@ internal class CompositeStackNavigatorTest {
     }
 
     class TestCompositeStackNavigator(
-        private val initialStack: List<Navigator<out Navigator.Events>>
-    ) : CompositeStackNavigator<Navigator.Events>(null) {
+        private val initialStack: List<Navigator>
+    ) : CompositeStackNavigator(null) {
 
-        override fun initialStack(): List<Navigator<out Navigator.Events>> {
+        override fun initialStack(): List<Navigator> {
             return initialStack
         }
 
         override fun instantiateNavigator(
-            navigatorClass: Class<Navigator<*>>,
+            navigatorClass: Class<Navigator>,
             state: NavigatorState?
-        ): Navigator<out Navigator.Events> {
+        ): Navigator {
             error("Not supported")
         }
     }
@@ -1060,7 +1060,7 @@ internal class CompositeStackNavigatorTest {
     open class TestSingleSceneNavigator(
         private val scene: Scene<out Container>,
         savedState: NavigatorState? = null
-    ) : SingleSceneNavigator<Navigator.Events>(savedState) {
+    ) : SingleSceneNavigator(savedState) {
 
         override fun createScene(state: SceneState?): Scene<out Container> {
             return scene
@@ -1070,7 +1070,7 @@ internal class CompositeStackNavigatorTest {
     open class TestStackNavigator(
         private val initialStack: List<TestScene>,
         savedState: NavigatorState? = null
-    ) : StackNavigator<Navigator.Events>(savedState) {
+    ) : StackNavigator(savedState) {
 
         override fun initialStack(): List<Scene<out Container>> {
             return initialStack
@@ -1085,18 +1085,18 @@ internal class CompositeStackNavigatorTest {
     }
 
     class RestorableTestCompositeStackNavigator(
-        private val initialStack: List<Navigator<out Navigator.Events>>,
+        private val initialStack: List<Navigator>,
         savedState: NavigatorState?
-    ) : CompositeStackNavigator<Navigator.Events>(savedState) {
+    ) : CompositeStackNavigator(savedState) {
 
-        override fun initialStack(): List<Navigator<out Navigator.Events>> {
+        override fun initialStack(): List<Navigator> {
             return initialStack
         }
 
         override fun instantiateNavigator(
-            navigatorClass: Class<Navigator<*>>,
+            navigatorClass: Class<Navigator>,
             state: NavigatorState?
-        ): Navigator<out Navigator.Events> {
+        ): Navigator {
             return when (navigatorClass) {
                 RestorableTestSingleSceneNavigator::class.java -> RestorableTestSingleSceneNavigator(
                     TestScene(0),
@@ -1111,7 +1111,7 @@ internal class CompositeStackNavigatorTest {
     open class RestorableTestSingleSceneNavigator(
         private val scene: Scene<out Container>,
         savedState: NavigatorState? = null
-    ) : SingleSceneNavigator<Navigator.Events>(savedState) {
+    ) : SingleSceneNavigator(savedState) {
 
         override fun createScene(state: SceneState?): Scene<out Container> {
             return state?.let { TestScene.create(it) } ?: scene

--- a/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/ReplacingNavigatorTest.kt
+++ b/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/ReplacingNavigatorTest.kt
@@ -47,7 +47,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `inactive navigator is not finished`() {
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.finished).toBe(false)
@@ -92,7 +92,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `inactive navigator does not notify newly added listener of scene`() {
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBeNull()
@@ -104,7 +104,7 @@ internal class ReplacingNavigatorTest {
             navigator.onStart()
 
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBe(initialScene)
@@ -113,7 +113,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `starting navigator notifies listeners of scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -125,7 +125,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `starting navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -137,7 +137,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `stopping navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStop()
@@ -149,7 +149,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `destroying navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onDestroy()
@@ -161,7 +161,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `onBackPressed notifies listeners of finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             val result = navigator.onBackPressed()
@@ -174,7 +174,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `replacing scene notifies listener of new scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
 
             /* When */
@@ -191,7 +191,7 @@ internal class ReplacingNavigatorTest {
             navigator.replace(scene1)
 
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBe(scene1)
@@ -200,7 +200,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `replacing scene after navigator stopped does not notify listener of new scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
             navigator.onStop()
 
@@ -214,7 +214,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `replacing scene after navigator destroyed does not notify listener of new scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
             navigator.onDestroy()
 
@@ -228,7 +228,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `starting navigator after scene changed in inactive state notifies listeners of new scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
             navigator.onStop()
             navigator.replace(scene1)
@@ -243,7 +243,7 @@ internal class ReplacingNavigatorTest {
         @Test
         fun `onBackPressed after scene change notifies listeners of finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
             navigator.replace(scene1)
 
@@ -461,7 +461,7 @@ internal class ReplacingNavigatorTest {
             val bundle = navigator.saveInstanceState()
             val restoredNavigator = RestorableReplacingNavigator(bundle)
             restoredNavigator.onStart()
-            restoredNavigator.addListener(listener)
+            restoredNavigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene?.foo).toBe(3)
@@ -478,7 +478,7 @@ internal class ReplacingNavigatorTest {
             val bundle = navigator.saveInstanceState()
             val restoredNavigator = RestorableReplacingNavigator(bundle)
             restoredNavigator.onStart()
-            restoredNavigator.addListener(listener)
+            restoredNavigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene?.foo).toBe(42)
@@ -502,7 +502,7 @@ internal class ReplacingNavigatorTest {
     }
 
     private class TestReplacingNavigator(savedState: com.nhaarman.bravo.state.NavigatorState?) :
-        ReplacingNavigator<Navigator.Events>(savedState) {
+        ReplacingNavigator(savedState) {
 
         val initialScenes = listOf(
             spy(TestScene(0)),
@@ -529,7 +529,7 @@ internal class ReplacingNavigatorTest {
     }
 
     private class RestorableReplacingNavigator(savedState: com.nhaarman.bravo.state.NavigatorState?) :
-        ReplacingNavigator<Navigator.Events>(savedState) {
+        ReplacingNavigator(savedState) {
 
         val initialScene = TestScene(0)
         override fun initialScene(): Scene<*> {

--- a/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/SingleSceneNavigatorTest.kt
+++ b/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/SingleSceneNavigatorTest.kt
@@ -44,7 +44,7 @@ class SingleSceneNavigatorTest {
         @Test
         fun `inactive navigator is not finished`() {
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.finished).toBe(false)
@@ -89,7 +89,7 @@ class SingleSceneNavigatorTest {
         @Test
         fun `inactive navigator does not notify newly added listener of scene`() {
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBeNull()
@@ -101,7 +101,7 @@ class SingleSceneNavigatorTest {
             navigator.onStart()
 
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBe(navigator.scene)
@@ -110,7 +110,7 @@ class SingleSceneNavigatorTest {
         @Test
         fun `starting navigator notifies listeners of scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -122,7 +122,7 @@ class SingleSceneNavigatorTest {
         @Test
         fun `starting navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -134,7 +134,7 @@ class SingleSceneNavigatorTest {
         @Test
         fun `stopping navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStop()
@@ -146,7 +146,7 @@ class SingleSceneNavigatorTest {
         @Test
         fun `destroying navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onDestroy()
@@ -158,7 +158,7 @@ class SingleSceneNavigatorTest {
         @Test
         fun `onBackPressed notifies listeners of finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             val result = navigator.onBackPressed()
@@ -355,7 +355,7 @@ class SingleSceneNavigatorTest {
         }
     }
 
-    class TestSingleSceneNavigator(savedState: NavigatorState?) : SingleSceneNavigator<Navigator.Events>(savedState) {
+    class TestSingleSceneNavigator(savedState: NavigatorState?) : SingleSceneNavigator(savedState) {
 
         lateinit var scene: TestScene
 

--- a/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/StackNavigatorTest.kt
+++ b/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/StackNavigatorTest.kt
@@ -50,7 +50,7 @@ internal class StackNavigatorTest {
         @Test
         fun `inactive navigator is not finished`() {
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.finished).toBe(false)
@@ -95,7 +95,7 @@ internal class StackNavigatorTest {
         @Test
         fun `inactive navigator does not notify newly added listener of scene`() {
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBeNull()
@@ -107,7 +107,7 @@ internal class StackNavigatorTest {
             navigator.onStart()
 
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBe(scene1)
@@ -116,7 +116,7 @@ internal class StackNavigatorTest {
         @Test
         fun `starting navigator notifies listeners of scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -128,7 +128,7 @@ internal class StackNavigatorTest {
         @Test
         fun `starting navigator multiple times notifies listeners of scene only once`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -141,7 +141,7 @@ internal class StackNavigatorTest {
         @Test
         fun `starting navigator - scene notification has no transition data`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -153,7 +153,7 @@ internal class StackNavigatorTest {
         @Test
         fun `starting navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -165,7 +165,7 @@ internal class StackNavigatorTest {
         @Test
         fun `stopping navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStop()
@@ -177,7 +177,7 @@ internal class StackNavigatorTest {
         @Test
         fun `destroying navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onDestroy()
@@ -189,7 +189,7 @@ internal class StackNavigatorTest {
         @Test
         fun `pushing a scene for inactive navigator does not notify listeners`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.push(scene2)
@@ -201,7 +201,7 @@ internal class StackNavigatorTest {
         @Test
         fun `pushing a scene for destroyed navigator does not notify listeners`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onDestroy()
 
             /* When */
@@ -214,7 +214,7 @@ internal class StackNavigatorTest {
         @Test
         fun `pushing a scene for active navigator does notify listeners`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
 
             /* When */
@@ -227,7 +227,7 @@ internal class StackNavigatorTest {
         @Test
         fun `pushing a scene for active navigator - scene notification has forward transition data`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
 
             /* When */
@@ -240,7 +240,7 @@ internal class StackNavigatorTest {
         @Test
         fun `start navigator after scene push notifies pushed scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.push(scene2)
 
             /* When */
@@ -253,7 +253,7 @@ internal class StackNavigatorTest {
         @Test
         fun `popping from single item stack for inactive navigator notifies finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.pop()
@@ -265,7 +265,7 @@ internal class StackNavigatorTest {
         @Test
         fun `popping from multi item stack for inactive navigator does not notify finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.push(scene2)
 
             /* When */
@@ -278,7 +278,7 @@ internal class StackNavigatorTest {
         @Test
         fun `popping from multi item stack for inactive navigator does not notify scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.push(scene2)
 
             /* When */
@@ -291,7 +291,7 @@ internal class StackNavigatorTest {
         @Test
         fun `popping from single item stack for active navigator notifies finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
 
             /* When */
@@ -304,7 +304,7 @@ internal class StackNavigatorTest {
         @Test
         fun `popping from multi item stack for active navigator does not notify finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
             navigator.push(scene2)
 
@@ -318,7 +318,7 @@ internal class StackNavigatorTest {
         @Test
         fun `popping from multi item stack for active navigator notifies proper scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
             navigator.push(scene2)
 
@@ -332,7 +332,7 @@ internal class StackNavigatorTest {
         @Test
         fun `popping from multi item stack for active navigator - scene notification has backward transition data`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
             navigator.push(scene2)
 
@@ -346,7 +346,7 @@ internal class StackNavigatorTest {
         @Test
         fun `popping from multi item stack for destroyed navigator does not notify scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onDestroy()
             navigator.push(scene2)
 
@@ -360,7 +360,7 @@ internal class StackNavigatorTest {
         @Test
         fun `onBackPressed for single scene stack notifies listeners of finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
 
             /* When */
@@ -374,7 +374,7 @@ internal class StackNavigatorTest {
         @Test
         fun `onBackPressed for single scene stack for inactive navigator notifies listeners of finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             val result = navigator.onBackPressed()
@@ -850,7 +850,7 @@ internal class StackNavigatorTest {
 
             val restoredNavigator = TestStackNavigator(listOf(scene1), bundle)
             restoredNavigator.onStart()
-            restoredNavigator.addListener(listener)
+            restoredNavigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene?.foo).toBe(3)
@@ -868,7 +868,7 @@ internal class StackNavigatorTest {
             val bundle = navigator.saveInstanceState()
             val restoredNavigator = TestStackNavigator(listOf(scene1), bundle)
             restoredNavigator.onStart()
-            restoredNavigator.addListener(listener)
+            restoredNavigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene?.foo).toBe(42)
@@ -879,7 +879,7 @@ internal class StackNavigatorTest {
             /* When */
             val result = TestStackNavigator(listOf(scene1), NavigatorState())
             result.onStart()
-            result.addListener(listener)
+            result.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBe(scene1)
@@ -895,7 +895,7 @@ internal class StackNavigatorTest {
             /* When */
             val result = TestStackNavigator(listOf(scene1), state)
             result.onStart()
-            result.addListener(listener)
+            result.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBe(scene1)
@@ -905,7 +905,7 @@ internal class StackNavigatorTest {
     class TestStackNavigator(
         private val initialStack: List<TestScene>,
         savedState: NavigatorState? = null
-    ) : StackNavigator<Navigator.Events>(savedState) {
+    ) : StackNavigator(savedState) {
 
         override fun initialStack(): List<Scene<out Container>> {
             return initialStack

--- a/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/WizardNavigatorTest.kt
+++ b/ext/bravo/src/test/java/com/nhaarman/bravo/navigation/WizardNavigatorTest.kt
@@ -49,7 +49,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `inactive navigator is not finished`() {
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.finished).toBe(false)
@@ -58,7 +58,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `inactive navigator does not notify newly added listener of scene`() {
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBeNull()
@@ -70,7 +70,7 @@ internal class WizardNavigatorTest {
             navigator.onStart()
 
             /* When */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene).toBe(scene1)
@@ -79,7 +79,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `starting navigator notifies listeners of scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -91,7 +91,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `starting navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStart()
@@ -103,7 +103,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `stopping navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onStop()
@@ -115,7 +115,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `destroying navigator does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.onDestroy()
@@ -127,7 +127,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `going to next scene for inactive navigator does not notify listeners`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.next()
@@ -139,7 +139,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `going to next scene for destroyed navigator does not notify listeners`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onDestroy()
 
             /* When */
@@ -152,7 +152,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `going to next scene for active navigator does notify listeners`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
 
             /* When */
@@ -165,7 +165,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `start navigator after going to next scene notifies pushed scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.next()
 
             /* When */
@@ -178,7 +178,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `going to previous screen when on first screen does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             navigator.previous()
@@ -190,7 +190,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `going back from second screen does not finish`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
             navigator.next()
 
@@ -204,7 +204,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `going back from second screen for active navigator notifies proper scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
             navigator.next()
 
@@ -218,7 +218,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `going back from second screen for destroyed navigator does not notify scene`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onDestroy()
             navigator.next()
 
@@ -232,7 +232,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `going to next for last scene notifies for active navigator notifies finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.next()
 
             /* When */
@@ -245,7 +245,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `onBackPressed for single scene stack notifies listeners of finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
             navigator.onStart()
 
             /* When */
@@ -259,7 +259,7 @@ internal class WizardNavigatorTest {
         @Test
         fun `onBackPressed for single scene stack for inactive navigator notifies listeners of finished`() {
             /* Given */
-            navigator.addListener(listener)
+            navigator.addNavigatorEventsListener(listener)
 
             /* When */
             val result = navigator.onBackPressed()
@@ -805,7 +805,7 @@ internal class WizardNavigatorTest {
             scene1.foo = 6
             val restoredNavigator = TestWizardNavigator(listOf(scene1), bundle)
             restoredNavigator.onStart()
-            restoredNavigator.addListener(listener)
+            restoredNavigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene?.foo).toBe(3)
@@ -826,7 +826,7 @@ internal class WizardNavigatorTest {
 
             val restoredNavigator = TestWizardNavigator(listOf(scene1, scene2), bundle)
             restoredNavigator.onStart()
-            restoredNavigator.addListener(listener)
+            restoredNavigator.addNavigatorEventsListener(listener)
 
             /* Then */
             expect(listener.lastScene?.foo).toBe(42)
@@ -836,7 +836,7 @@ internal class WizardNavigatorTest {
     class TestWizardNavigator(
         private val initialStack: List<TestScene>,
         savedState: NavigatorState? = null
-    ) : WizardNavigator<Navigator.Events>(savedState) {
+    ) : WizardNavigator(savedState) {
 
         override fun createScene(index: Int): Scene<out Container>? {
             return initialStack.getOrNull(index)

--- a/samples/hello-navigation/src/main/java/com/nhaarman/bravo/samples/hellonavigation/HelloNavigationNavigator.kt
+++ b/samples/hello-navigation/src/main/java/com/nhaarman/bravo/samples/hellonavigation/HelloNavigationNavigator.kt
@@ -35,7 +35,7 @@ import com.nhaarman.bravo.presentation.Scene
  */
 class HelloNavigationNavigator :
 // Extends StackNavigator to allow for pushing and popping Scenes of a stack.
-    StackNavigator<Navigator.Events>(null),
+    StackNavigator(null),
     // Implements the callbacks for the Scene to execute Scene transitions.
     FirstScene.Events,
     SecondScene.Events {

--- a/samples/hello-startactivity/src/main/java/com/nhaarman/bravo/samples/hellostartactivity/HelloStartActivityNavigator.kt
+++ b/samples/hello-startactivity/src/main/java/com/nhaarman/bravo/samples/hellostartactivity/HelloStartActivityNavigator.kt
@@ -36,7 +36,7 @@ import com.nhaarman.bravo.state.SceneState
  */
 class HelloStartActivityNavigator(
     savedState: NavigatorState?
-) : StackNavigator<Navigator.Events>(savedState),
+) : StackNavigator(savedState),
     FirstScene.Events,
     MapsScene.Events {
 

--- a/samples/hello-staterestoration/src/main/java/com/nhaarman/bravo/samples/hellostaterestoration/HelloStateRestorationNavigator.kt
+++ b/samples/hello-staterestoration/src/main/java/com/nhaarman/bravo/samples/hellostaterestoration/HelloStateRestorationNavigator.kt
@@ -35,7 +35,7 @@ import com.nhaarman.bravo.state.get
 class HelloStateRestorationNavigator private constructor(
     private var counter: Int,
     savedState: NavigatorState?
-) : StackNavigator<Navigator.Events>(savedState),
+) : StackNavigator(savedState),
     HelloStateRestorationScene.Events {
 
     override fun initialStack(): List<Scene<out Container>> {

--- a/samples/hello-world/src/main/java/com/nhaarman/bravo/samples/helloworld/HelloWorldNavigator.kt
+++ b/samples/hello-world/src/main/java/com/nhaarman/bravo/samples/helloworld/HelloWorldNavigator.kt
@@ -30,7 +30,7 @@ import com.nhaarman.bravo.presentation.Scene
  * This Navigator does not handle any state restoration, since there is no state
  * worth saving.
  */
-class HelloWorldNavigator : SingleSceneNavigator<Navigator.Events>(null) {
+class HelloWorldNavigator : SingleSceneNavigator(null) {
 
     override fun createScene(state: SceneState?): Scene<out Container> {
         return HelloWorldScene()

--- a/samples/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/navigation/CreateItemNavigator.kt
+++ b/samples/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/navigation/CreateItemNavigator.kt
@@ -18,22 +18,21 @@
 
 package com.nhaarman.bravo.notesapp.navigation
 
-import com.nhaarman.bravo.state.NavigatorState
-import com.nhaarman.bravo.state.SceneState
-import com.nhaarman.bravo.navigation.Navigator
 import com.nhaarman.bravo.navigation.SingleSceneNavigator
 import com.nhaarman.bravo.notesapp.NotesAppComponent
 import com.nhaarman.bravo.notesapp.note.NoteItem
 import com.nhaarman.bravo.notesapp.presentation.createitem.CreateItemScene
 import com.nhaarman.bravo.presentation.Container
 import com.nhaarman.bravo.presentation.Scene
+import com.nhaarman.bravo.state.NavigatorState
+import com.nhaarman.bravo.state.SceneState
 
 class CreateItemNavigator(
     private val text: String?,
     private val notesAppComponent: NotesAppComponent,
     private val savedState: NavigatorState?,
     private val listener: Events
-) : SingleSceneNavigator<CreateItemNavigator.Events>(savedState),
+) : SingleSceneNavigator(savedState),
     CreateItemScene.Events {
 
     override fun createScene(state: SceneState?): Scene<out Container> {
@@ -49,7 +48,7 @@ class CreateItemNavigator(
         listener.created(noteItem)
     }
 
-    interface Events : Navigator.Events {
+    interface Events {
 
         fun created(noteItem: NoteItem)
     }

--- a/samples/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/navigation/NotesAppNavigator.kt
+++ b/samples/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/navigation/NotesAppNavigator.kt
@@ -18,30 +18,31 @@
 
 package com.nhaarman.bravo.notesapp.navigation
 
-import com.nhaarman.bravo.state.NavigatorState
 import com.nhaarman.bravo.navigation.CompositeStackNavigator
 import com.nhaarman.bravo.navigation.Navigator
 import com.nhaarman.bravo.notesapp.NotesAppComponent
 import com.nhaarman.bravo.notesapp.note.NoteItem
+import com.nhaarman.bravo.state.NavigatorState
 
 class NotesAppNavigator(
     private val notesAppComponent: NotesAppComponent,
     savedState: NavigatorState?
-) : CompositeStackNavigator<Navigator.Events>(savedState),
+) : CompositeStackNavigator(savedState),
     PrimaryNavigator.Events,
     CreateItemNavigator.Events {
 
-    override fun initialStack(): List<Navigator<out Navigator.Events>> {
-        return listOf(PrimaryNavigator(notesAppComponent, null))
+    override fun initialStack(): List<Navigator> {
+        return listOf(PrimaryNavigator(notesAppComponent, this, null))
     }
 
     override fun instantiateNavigator(
-        navigatorClass: Class<Navigator<*>>,
+        navigatorClass: Class<Navigator>,
         state: NavigatorState?
-    ): Navigator<out Navigator.Events> {
+    ): Navigator {
         return when (navigatorClass) {
             PrimaryNavigator::class.java -> PrimaryNavigator(
                 notesAppComponent,
+                this,
                 state
             )
             CreateItemNavigator::class.java -> CreateItemNavigator(

--- a/samples/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/navigation/PrimaryNavigator.kt
+++ b/samples/notes-app/bravo/src/main/java/com/nhaarman/bravo/notesapp/navigation/PrimaryNavigator.kt
@@ -18,7 +18,6 @@
 
 package com.nhaarman.bravo.notesapp.navigation
 
-import com.nhaarman.bravo.navigation.Navigator
 import com.nhaarman.bravo.navigation.StackNavigator
 import com.nhaarman.bravo.notesapp.NotesAppComponent
 import com.nhaarman.bravo.notesapp.note.NoteItem
@@ -35,8 +34,9 @@ import com.nhaarman.bravo.state.SceneState
  */
 class PrimaryNavigator(
     private val notesAppComponent: NotesAppComponent,
+    private val listener: Events,
     savedState: NavigatorState?
-) : StackNavigator<PrimaryNavigator.Events>(savedState),
+) : StackNavigator(savedState),
     ItemListScene.Events,
     EditItemScene.Events {
 
@@ -54,7 +54,7 @@ class PrimaryNavigator(
     override fun deleted() = pop()
 
     override fun createItemRequested() {
-        listeners.forEach { it.createItemRequested() }
+        listener.createItemRequested()
     }
 
     override fun showItemRequested(item: NoteItem) {
@@ -83,7 +83,7 @@ class PrimaryNavigator(
         }
     }
 
-    interface Events : Navigator.Events {
+    interface Events {
 
         fun createItemRequested()
     }


### PR DESCRIPTION
Instead of extending the Navigator.Events interface
to add results or other events to the Navigator,
this commit decouples these two types of events.

Coupling these two causes a lot of unchecked casts
to be necessary and with that can lead to unexpected
crashes when a potential listener does not adhere to
the full contract.

This is especially necessary when dealing with 
Activity results such as in #4.