### PR TITLE
Remove Android Ktx dependency

### DIFF
--- a/ext/bravo-android/build.gradle
+++ b/ext/bravo-android/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     api project(":bravo-android")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
-    implementation "androidx.core:core-ktx"
 
     implementation "com.android.support:interpolator"
     compileOnly "com.android.support:appcompat-v7"

--- a/ext/bravo-android/src/androidTest/java/com/nhaarman/bravo/android/util/BundleTest.kt
+++ b/ext/bravo-android/src/androidTest/java/com/nhaarman/bravo/android/util/BundleTest.kt
@@ -21,7 +21,6 @@ package com.nhaarman.bravo.android.util
 import android.os.Parcel
 import android.os.Parcelable
 import android.util.SparseArray
-import androidx.core.util.set
 import com.nhaarman.bravo.state.NavigatorState
 import com.nhaarman.bravo.state.containerState
 import com.nhaarman.bravo.state.navigatorState
@@ -50,6 +49,21 @@ class BundleTest {
         /* Given */
         val state = navigatorState {
             it["transformToBravo"] = 3.14
+        }
+
+        /* When */
+        val result = state.toBundle().toNavigatorState()
+
+        /* Then */
+        expect(result).toBe(state)
+    }
+
+    @Test
+    fun toAndFromBundle_multipleKeys() {
+        /* Given */
+        val state = navigatorState {
+            it["key1"] = 3.14
+            it["key2"] = "test"
         }
 
         /* When */
@@ -100,7 +114,7 @@ class BundleTest {
     fun toAndFromBundle_sparseParcelableArray() {
         /* Given */
         val array = SparseArray<Parcelable>(3)
-        array[0] = MyParcelable(3)
+        array.put(0, MyParcelable(3))
 
         val state = navigatorState {
             it.setUnchecked("array", array)

--- a/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/FadeInFromBottomTransition.kt
+++ b/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/FadeInFromBottomTransition.kt
@@ -21,11 +21,10 @@ package com.nhaarman.bravo.android.transition
 import android.support.v4.view.animation.LinearOutSlowInInterpolator
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.children
-import androidx.core.view.doOnPreDraw
 import com.nhaarman.bravo.android.R
 import com.nhaarman.bravo.android.internal.applyWindowBackground
 import com.nhaarman.bravo.android.presentation.ViewResult
+import com.nhaarman.bravo.android.transition.internal.doOnPreDraw
 
 /**
  * A transition that fades the new [View] from the bottom.
@@ -38,7 +37,7 @@ class FadeInFromBottomTransition(
 ) : Transition {
 
     override fun execute(parent: ViewGroup, callback: Transition.Callback) {
-        val originalChildren = parent.children.asIterable().toList()
+        val originalChildren = (0..parent.childCount).map { parent.getChildAt(it) }
 
         val newViewResult = view(parent)
 

--- a/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/FadeOutToBottomTransition.kt
+++ b/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/FadeOutToBottomTransition.kt
@@ -21,12 +21,11 @@ package com.nhaarman.bravo.android.transition
 import android.support.v4.view.animation.FastOutLinearInInterpolator
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.children
-import androidx.core.view.doOnPreDraw
 import com.nhaarman.bravo.android.R
 import com.nhaarman.bravo.android.internal.applyWindowBackground
 import com.nhaarman.bravo.android.presentation.ViewFactory
 import com.nhaarman.bravo.android.presentation.ViewResult
+import com.nhaarman.bravo.android.transition.internal.doOnPreDraw
 import com.nhaarman.bravo.presentation.Scene
 
 /**
@@ -46,7 +45,7 @@ class FadeOutToBottomTransition(
 
     override fun execute(parent: ViewGroup, callback: Transition.Callback) {
         // We're assuming a single View is present.
-        val originalChildren = parent.children.asIterable().toList()
+        val originalChildren = (0..parent.childCount).map { parent.getChildAt(it) }
         val originalView = originalChildren.firstOrNull()
 
         val newViewResult = view(parent)

--- a/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/internal/View.kt
+++ b/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/transition/internal/View.kt
@@ -1,0 +1,39 @@
+/*
+ * Bravo - Decoupling navigation from Android
+ * Copyright (C) 2018 Niek Haarman
+ *
+ * Bravo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bravo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Bravo.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nhaarman.bravo.android.transition.internal
+
+import android.view.View
+import android.view.ViewTreeObserver
+
+/**
+ * Copyright (C) 2018 The Android Open Source Project
+ */
+internal inline fun View.doOnPreDraw(crossinline f: () -> Unit) {
+    val viewTreeObserver = viewTreeObserver
+    viewTreeObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
+        override fun onPreDraw(): Boolean {
+            f()
+            when {
+                viewTreeObserver.isAlive -> viewTreeObserver.removeOnPreDrawListener(this)
+                else -> viewTreeObserver.removeOnPreDrawListener(this)
+            }
+            return true
+        }
+    })
+}

--- a/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/util/Bundle.kt
+++ b/ext/bravo-android/src/main/java/com/nhaarman/bravo/android/util/Bundle.kt
@@ -18,43 +18,122 @@
 
 package com.nhaarman.bravo.android.util
 
+import android.os.Binder
+import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
+import android.util.Size
+import android.util.SizeF
 import android.util.SparseArray
-import androidx.core.os.bundleOf
 import com.nhaarman.bravo.state.ContainerState
 import com.nhaarman.bravo.state.NavigatorState
 import com.nhaarman.bravo.state.SavedState
 import com.nhaarman.bravo.state.SceneState
+import java.io.Serializable
 import kotlin.collections.component1
 import kotlin.collections.component2
 
-fun SavedState.toBundle(): Bundle {
-    return entries
-        .filter { (_, value) -> value !is SparseArray<*> }
-        .map { (key, value) ->
+/**
+ * Copyright (C) 2018 The Android Open Source Project
+ */
+private fun Bundle.put(key: String, value: Any?) {
+    when (value) {
+        null -> putString(key, null) // Any nullable type will suffice.
 
-            val v = when (value) {
-                is NavigatorState -> bundleOf("type" to "navigator_state", "state" to value.toBundle())
-                is SceneState -> bundleOf("type" to "scene_state", "state" to value.toBundle())
-                is ContainerState -> bundleOf("type" to "container_state", "state" to value.toBundle())
-                is SavedState -> bundleOf("type" to "saved_state", "state" to value.toBundle())
-                else -> value
-            }
+        // Scalars
+        is Boolean -> putBoolean(key, value)
+        is Byte -> putByte(key, value)
+        is Char -> putChar(key, value)
+        is Double -> putDouble(key, value)
+        is Float -> putFloat(key, value)
+        is Int -> putInt(key, value)
+        is Long -> putLong(key, value)
+        is Short -> putShort(key, value)
 
-            key to v
-        }
-        .toTypedArray()
-        .let(::bundleOf)
-        .also { bundle ->
+        // References
+        is Bundle -> putBundle(key, value)
+        is CharSequence -> putCharSequence(key, value)
+        is Parcelable -> putParcelable(key, value)
 
-            entries
-                .filter { (_, value) -> value is SparseArray<*> }
-                .forEach { (key, value) ->
-                    /* This is arguably a Bad Thing(TM), but we need this for view state saving. */
-                    @Suppress("UNCHECKED_CAST")
-                    bundle.putSparseParcelableArray(key, value as SparseArray<out Parcelable>)
+        // Scalar arrays
+        is BooleanArray -> putBooleanArray(key, value)
+        is ByteArray -> putByteArray(key, value)
+        is CharArray -> putCharArray(key, value)
+        is DoubleArray -> putDoubleArray(key, value)
+        is FloatArray -> putFloatArray(key, value)
+        is IntArray -> putIntArray(key, value)
+        is LongArray -> putLongArray(key, value)
+        is ShortArray -> putShortArray(key, value)
+
+        // Reference arrays
+        is Array<*> -> {
+            val componentType = value::class.java.componentType!!
+            @Suppress("UNCHECKED_CAST") // Checked by reflection.
+            when {
+                Parcelable::class.java.isAssignableFrom(componentType) -> {
+                    putParcelableArray(key, value as Array<Parcelable>)
                 }
+                String::class.java.isAssignableFrom(componentType) -> {
+                    putStringArray(key, value as Array<String>)
+                }
+                CharSequence::class.java.isAssignableFrom(componentType) -> {
+                    putCharSequenceArray(key, value as Array<CharSequence>)
+                }
+                Serializable::class.java.isAssignableFrom(componentType) -> {
+                    putSerializable(key, value)
+                }
+                else -> {
+                    val valueType = componentType.canonicalName
+                    throw IllegalArgumentException(
+                        "Illegal value array type $valueType for key \"$key\""
+                    )
+                }
+            }
+        }
+
+        // State types
+        is NavigatorState -> put(key, bundleOf("type" to "navigator_state", "state" to value.toBundle()))
+        is SceneState -> put(key, bundleOf("type" to "scene_state", "state" to value.toBundle()))
+        is ContainerState -> put(key, bundleOf("type" to "container_state", "state" to value.toBundle()))
+        is SavedState -> put(key, bundleOf("type" to "saved_state", "state" to value.toBundle()))
+
+        // Last resort. Also we must check this after Array<*> as all arrays are serializable.
+        is Serializable -> putSerializable(key, value)
+
+        else -> {
+            if (value is SparseArray<*>) {
+                /* This is arguably a Bad Thing(TM), but we need this for view state saving. */
+                @Suppress("UNCHECKED_CAST")
+                putSparseParcelableArray(key, value as SparseArray<out Parcelable>)
+            } else if (value is Binder) {
+                putBinder(key, value)
+            } else if (Build.VERSION.SDK_INT >= 21 && value is Size) {
+                putSize(key, value)
+            } else if (Build.VERSION.SDK_INT >= 21 && value is SizeF) {
+                putSizeF(key, value)
+            } else {
+                val valueType = value.javaClass.canonicalName
+                throw IllegalArgumentException("Illegal value type $valueType for key \"$key\"")
+            }
+        }
+    }
+}
+
+private fun bundleOf(vararg values: Pair<String, Any?>): Bundle {
+    return Bundle()
+        .also { b ->
+            values.forEach { (key, value) ->
+                b.put(key, value)
+            }
+        }
+}
+
+fun SavedState.toBundle(): Bundle {
+    return Bundle(entries.size)
+        .apply {
+            entries.forEach { (key, value) ->
+                put(key, value)
+            }
         }
 }
 


### PR DESCRIPTION
Depending on ktx version 0.3 causes collisions when client
apps use the new AndroidX libraries. Upgrading to 1.0.0
however requires the entire library to enforce AndroidX
on the client app. Removing the artifact from this library
avoids the issue as a whole.