### PR TITLE
Introduce RxScene.whenStarted

### DIFF
--- a/samples/hello-sharedata/src/main/java/com/nhaarman/bravo/samples/hellosharedata/presentation/picturegallery/PictureGalleryScene.kt
+++ b/samples/hello-sharedata/src/main/java/com/nhaarman/bravo/samples/hellosharedata/presentation/picturegallery/PictureGalleryScene.kt
@@ -31,6 +31,8 @@ class PictureGalleryScene(
 ) : RxScene<PictureGalleryContainer>(savedState) {
 
     override fun onStart() {
+        super.onStart()
+
         disposables += picturesProvider.pictures
             .combineWithLatestView()
             .subscribe { (pictures, container) ->

--- a/samples/notes-app/src/main/java/com/nhaarman/bravo/notesapp/presentation/createitem/CreateItemScene.kt
+++ b/samples/notes-app/src/main/java/com/nhaarman/bravo/notesapp/presentation/createitem/CreateItemScene.kt
@@ -18,12 +18,12 @@
 
 package com.nhaarman.bravo.notesapp.presentation.createitem
 
-import com.nhaarman.bravo.state.SceneState
 import com.nhaarman.bravo.notesapp.mainThread
 import com.nhaarman.bravo.notesapp.note.NoteItem
 import com.nhaarman.bravo.notesapp.note.NoteItemsRepository
 import com.nhaarman.bravo.presentation.RxScene
 import com.nhaarman.bravo.presentation.SceneKey.Companion.defaultKey
+import com.nhaarman.bravo.state.SceneState
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.plusAssign
 import io.reactivex.rxkotlin.withLatestFrom
@@ -44,6 +44,8 @@ class CreateItemScene(
     private val createClicks = view.whenAvailable { it.createClicks }
 
     override fun onStart() {
+        super.onStart()
+
         disposables += createClicks
             .withLatestFrom(textObservable) { _, text -> text }
             .firstElement()

--- a/samples/notes-app/src/main/java/com/nhaarman/bravo/notesapp/presentation/edititem/EditItemScene.kt
+++ b/samples/notes-app/src/main/java/com/nhaarman/bravo/notesapp/presentation/edititem/EditItemScene.kt
@@ -43,6 +43,8 @@ class EditItemScene(
     private val deleteClicks = view.whenAvailable { it.deleteClicks }
 
     override fun onStart() {
+        super.onStart()
+
         disposables += originalItem
             .combineWithLatestView()
             .firstElement()

--- a/samples/notes-app/src/main/java/com/nhaarman/bravo/notesapp/presentation/itemlist/ItemListScene.kt
+++ b/samples/notes-app/src/main/java/com/nhaarman/bravo/notesapp/presentation/itemlist/ItemListScene.kt
@@ -44,6 +44,8 @@ class ItemListScene(
     }
 
     override fun onStart() {
+        super.onStart()
+
         disposables += items
             .combineWithLatestView()
             .subscribe { (items, view) ->


### PR DESCRIPTION
This allows users to automatically subscribe to
Observable sources when the Scene starts and to
automatically dispose of the subscription when
the Scene is stopped.
This can be useful in combination with
RxScene.autoConnect() to be able to easily cache
results:

```kotlin
val myData = whenStarted { source.data }
               .replay(1).autoConnect(this)
```