### PR TITLE
Ensure callbacks are executed _after_ the internal state has changed.

### DIFF
--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,5 +1,5 @@
 <component name="CopyrightManager">
-  <settings default="GNU GPLv3">
+  <settings>
     <module2copyright>
       <element module="Production .kt" copyright="GNU GPLv3" />
       <element module="Test .kt" copyright="GNU GPLv3" />


### PR DESCRIPTION
Executing callbacks before the state has changed may lead to
these callbacks synchronously executing methods on the stale state,
possibly leading to all kinds of issues.
This ensures that the state change is done first, before calling
any callback methods.