### PR TITLE
Don't require RestorableContainer for abstract Scenes

### DIFF
--- a/ext/acorn-android/acorn-android-lifecycle/src/main/java/com/nhaarman/acorn/presentation/LifecycleScene.kt
+++ b/ext/acorn-android/acorn-android-lifecycle/src/main/java/com/nhaarman/acorn/presentation/LifecycleScene.kt
@@ -18,18 +18,26 @@
 
 package com.nhaarman.acorn.presentation
 
+import androidx.annotation.CallSuper
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import androidx.annotation.CallSuper
 import com.nhaarman.acorn.state.SceneState
 
 /**
- * An abstract [Scene] implementation which implements [LifecycleOwner].
+ * An abstract base [Scene] implementation that provides commonly used
+ * functionality, and implements [LifecycleOwner].
  *
- * @see SavableScene
+ * @see BaseSavableScene
+ *
+ * @param V The view type for this [Scene]. Can implement [RestorableContainer]
+ * to save and restore view state between different views attached to the Scene.
+ * @param savedState A previous saved state instance for this [Scene].
+ * May be `null`.
+ * @constructor Creates a new [LifecycleScene], restoring view state when
+ * available.
  */
-abstract class LifecycleScene<V : RestorableContainer>(
+abstract class LifecycleScene<V : Container>(
     savedState: SceneState?
 ) : BaseSavableScene<V>(savedState), LifecycleOwner {
 

--- a/ext/acorn/acorn-rx/src/main/java/com/nhaarman/acorn/presentation/RxScene.kt
+++ b/ext/acorn/acorn-rx/src/main/java/com/nhaarman/acorn/presentation/RxScene.kt
@@ -33,15 +33,22 @@ import io.reactivex.rxkotlin.plusAssign
 import io.reactivex.subjects.BehaviorSubject
 
 /**
- * An abstract [Scene] implementation which provides a basic Rx implementation.
+ * An abstract base [Scene] implementation that provides commonly used
+ * functionality, including some helper functions for Rx usage.
  *
  * Implementers of this class gain access to the [view] property to get notified
  * of view changes, and a [disposables] property is provided for easy clearing
  * of [Disposable]s.
  *
- * @see SavableScene
+ * @see BaseSavableScene
+ *
+ * @param V The view type for this [Scene]. Can implement [RestorableContainer]
+ * to save and restore view state between different views attached to the Scene.
+ * @param savedState A previous saved state instance for this [Scene].
+ * May be `null`.
+ * @constructor Creates a new [RxScene], restoring view state when available.
  */
-abstract class RxScene<V : RestorableContainer>(
+abstract class RxScene<V : Container>(
     savedState: SceneState?
 ) : BaseSavableScene<V>(savedState) {
 

--- a/ext/acorn/src/main/java/com/nhaarman/acorn/presentation/BasicScene.kt
+++ b/ext/acorn/src/main/java/com/nhaarman/acorn/presentation/BasicScene.kt
@@ -22,33 +22,40 @@ import androidx.annotation.CallSuper
 import com.nhaarman.acorn.state.ContainerState
 
 /**
- * An abstract [Scene] implementation that saves and restores view state between
- * different views, and provides a reference to the currently attached view.
+ * A basic abstract [Scene] implementation that provides some basic functionality.
  *
- * @param V The view type for this [Scene], must implement [RestorableContainer].
+ * This class provides an [attachedView] property which provides the currently
+ * attached [V] instance, if available.
+ *
+ * @param V The view type for this [Scene]. Can implement [RestorableContainer]
+ * to save and restore view state between different views attached to the Scene.
  * @property containerState The initial view state for this [Scene].
+ * May be `null`.
  * @constructor Creates a new [BasicScene], restoring view state when available.
  */
-abstract class BasicScene<V : RestorableContainer> : Scene<V> {
-
+abstract class BasicScene<V : Container>(
     private var containerState: ContainerState? = null
+) : Scene<V> {
 
     /**
      * The currently attached [V] instance, if available.
+     *
+     * This property will be updated when [attach] or [detach] is called.
+     *
      * Returns `null` if no instance is attached.
      */
-    protected var currentView: V? = null
+    protected var attachedView: V? = null
         private set
 
     @CallSuper
     override fun attach(v: V) {
-        containerState?.let { v.restoreInstanceState(it) }
-        currentView = v
+        containerState?.let { (v as? RestorableContainer)?.restoreInstanceState(it) }
+        attachedView = v
     }
 
     @CallSuper
     override fun detach(v: V) {
-        containerState = v.saveInstanceState()
-        currentView = null
+        containerState = (v as? RestorableContainer)?.saveInstanceState()
+        attachedView = null
     }
 }

--- a/ext/acorn/src/test/java/com/nhaarman/acorn/presentation/BasicSceneTest.kt
+++ b/ext/acorn/src/test/java/com/nhaarman/acorn/presentation/BasicSceneTest.kt
@@ -68,7 +68,7 @@ class BasicSceneTest {
 
     private class TestBasicScene : BasicScene<TestView>() {
 
-        val view get() = currentView
+        val view get() = attachedView
     }
 
     private class TestView(var state: Int? = null) : Container, RestorableContainer {


### PR DESCRIPTION
Users can still provide a `RestorableContainer` to
make use of the automatic view state saving and
restoring functionality, but the interface will
not be forced upon them.