### PR TITLE
Use 'started' and 'stopped' for lifecycle states

### DIFF
--- a/core/acorn-core/src/main/java/com/nhaarman/acorn/navigation/Navigator.kt
+++ b/core/acorn-core/src/main/java/com/nhaarman/acorn/navigation/Navigator.kt
@@ -34,19 +34,19 @@ import com.nhaarman.acorn.presentation.Scene
  * manage. To be able to do this, the Navigator has a very simple lifecycle as
  * well:
  *
- *  - `inactive` : The Navigator is currently idle and will not emit any changes
+ *  - `stopped`  : The Navigator is currently idle and will not emit any changes
  *                 in Scenery.
- *  - `active`   : The Navigator is currently active and will notify interested
+ *  - `started`  : The Navigator is currently started and will notify interested
  *                 parties of changes in Scenes.
- *  - `destroyed`: The Navigator has been destroyed and will not become active
+ *  - `destroyed`: The Navigator has been destroyed and will not be started
  *                 anymore.
  *
- * Navigator instance start in the `inactive` state and can switch between
- * `inactive` and `active` an infinite amount of times.
+ * Navigator instances start in the `stopped` state and can switch between
+ * `stopped` and `started` an infinite amount of times.
  * Once a Navigator has been destroyed, it must be considered as dead, and any
  * further interactions with it will be ignored.
  *
- * Navigators that are not `active` must never have Scenes in their `active`
+ * Navigators that are not `started` must never have Scenes in their `started`
  * state.
  *
  * Navigators may implement [SavableNavigator] to indicate that their instance state

--- a/core/acorn-core/src/main/java/com/nhaarman/acorn/presentation/Scene.kt
+++ b/core/acorn-core/src/main/java/com/nhaarman/acorn/presentation/Scene.kt
@@ -26,14 +26,14 @@ package com.nhaarman.acorn.presentation
  *
  * The lifecycle of a Scene is very simple:
  *
- *  - 'inactive' : The Scene is dormant, waiting to become active or to
+ *  - 'stopped'  : The Scene is dormant, waiting to be started or to
  *                 be destroyed.
- *  - 'active'   : The Scene is active.
- *  - 'destroyed': The Scene is destroyed and will not become active anymore.
+ *  - 'started'  : The Scene is started.
+ *  - 'destroyed': The Scene is destroyed and will not be started anymore.
  *
  * On top of that, the user interface can attach to and detach itself from this
  * Scene via the [attach] and [detach] methods, providing interaction with
- * the user. It is therefore possible that the Scene is active without having
+ * the user. It is therefore possible that the Scene is started without having
  * a user interface attached.
  *
  * Scenes may implement [SavableScene] to indicate that their instance state
@@ -54,7 +54,7 @@ interface Scene<V : Container> {
     val key: SceneKey get() = SceneKey.from(javaClass)
 
     /**
-     * Called when this Scene becomes active.
+     * Called when this Scene is started.
      */
     fun onStart() {}
 
@@ -73,7 +73,7 @@ interface Scene<V : Container> {
     fun detach(v: V) {}
 
     /**
-     * Called when this Scene becomes inactive.
+     * Called when this Scene is stopped.
      */
     fun onStop() {}
 


### PR DESCRIPTION
Fixes #98 