### PR TITLE
Remove `CompositeDisposable.plusAssign`

### DIFF
--- a/ext/acorn/acorn-rx/src/main/java/com/nhaarman/acorn/navigation/DisposableHandle.kt
+++ b/ext/acorn/acorn-rx/src/main/java/com/nhaarman/acorn/navigation/DisposableHandle.kt
@@ -16,16 +16,7 @@
 
 package com.nhaarman.acorn.navigation
 
-import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
-
-/**
- * Adds given [disposableHandle] as a [Disposable] to the receiving
- * [CompositeDisposable].
- */
-operator fun CompositeDisposable.plusAssign(disposableHandle: DisposableHandle) {
-    add(disposableHandle.asDisposable())
-}
 
 /**
  * Wraps the receiving [DisposableHandle] as a [Disposable].

--- a/ext/acorn/acorn-rx/src/test/java/com/nhaarman/acorn/navigation/DisposableHandleTest.kt
+++ b/ext/acorn/acorn-rx/src/test/java/com/nhaarman/acorn/navigation/DisposableHandleTest.kt
@@ -1,0 +1,74 @@
+/*
+ *    Copyright 2018 Niek Haarman
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.nhaarman.acorn.navigation
+
+import com.nhaarman.expect.expect
+import org.junit.jupiter.api.Test
+
+class DisposableHandleTest {
+
+    @Test
+    fun `resulting disposable mirrors non disposed state`() {
+        /* Given */
+        val handle = SimpleDisposableHandle()
+
+        /* When */
+        val disposable = handle.asDisposable()
+
+        /* Then */
+        expect(disposable.isDisposed).toBe(false)
+    }
+
+    @Test
+    fun `resulting disposable mirrors disposed state`() {
+        /* Given */
+        val handle = SimpleDisposableHandle()
+
+        /* When */
+        val disposable = handle.asDisposable()
+        handle.dispose()
+
+        /* Then */
+        expect(disposable.isDisposed).toBe(true)
+    }
+
+    @Test
+    fun `resulting disposable delegates disposing to handle`() {
+        /* Given */
+        val handle = SimpleDisposableHandle()
+
+        /* When */
+        val disposable = handle.asDisposable()
+        disposable.dispose()
+
+        /* Then */
+        expect(handle.isDisposed()).toBe(true)
+    }
+
+    private class SimpleDisposableHandle : DisposableHandle {
+
+        private var isDisposed = false
+
+        override fun dispose() {
+            isDisposed = true
+        }
+
+        override fun isDisposed(): Boolean {
+            return isDisposed
+        }
+    }
+}


### PR DESCRIPTION
The library includes a `CompositeDisposable.plusAssign(DisposableHandle)`
function, which is used to easily add `DisposableHandle`s to a
`CompositeDisposable`. However, this is rarely used but really gets in
the way when using RxJava's `plusAssign` in the sense that the
auto-import may suggest the wrong import.

The `DisposableHandle.asDisposable()` function should be enough to deal
with this easily.

Fixes #112 