### PR TITLE
Rename 'Transition' interface to 'SceneTransition'

### DIFF
--- a/core/acorn-android-core/src/main/java/com/nhaarman/acorn/android/transition/SceneTransition.kt
+++ b/core/acorn-android-core/src/main/java/com/nhaarman/acorn/android/transition/SceneTransition.kt
@@ -24,7 +24,7 @@ import com.nhaarman.acorn.presentation.Scene
 /**
  * An interface to manually implement [Scene] transition animations.
  */
-interface Transition {
+interface SceneTransition {
 
     /**
      * Executes the transition.
@@ -46,9 +46,9 @@ interface Transition {
     fun execute(parent: ViewGroup, callback: Callback)
 
     /**
-     * A callback interface to be able to get notified when a [Transition] ends.
-     * Implementers of [Transition.execute], must always invoke [onComplete]
-     * when the [Transition] is finished.
+     * A callback interface to be able to get notified when a [SceneTransition] ends.
+     * Implementers of [SceneTransition.execute], must always invoke [onComplete]
+     * when the [SceneTransition] is finished.
      * Optionally, [attach] can be invoked during the transition animation to
      * have the view attached to the [Scene] before the animation ends.
      */
@@ -69,7 +69,7 @@ interface Transition {
         fun attach(viewController: ViewController)
 
         /**
-         * Implementers of [Transition.execute] must invoke this method when the
+         * Implementers of [SceneTransition.execute] must invoke this method when the
          * transition is finished. If no call to [attach] was made before
          * invoking this method, given [viewController] will be attached to the
          * [Scene].

--- a/ext/acorn-android/acorn-android-appcompat/src/main/java/com/nhaarman/acorn/android/AcornAppCompatActivity.kt
+++ b/ext/acorn-android/acorn-android-appcompat/src/main/java/com/nhaarman/acorn/android/AcornAppCompatActivity.kt
@@ -32,7 +32,7 @@ import com.nhaarman.acorn.android.presentation.SceneViewControllerFactory
 import com.nhaarman.acorn.android.presentation.ViewController
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
 import com.nhaarman.acorn.android.transition.DefaultTransitionFactory
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.transition.TransitionFactory
 import com.nhaarman.acorn.navigation.Navigator
 import com.nhaarman.acorn.presentation.Scene
@@ -69,7 +69,7 @@ abstract class AcornAppCompatActivity : AppCompatActivity() {
     }
 
     /**
-     * Returns the [TransitionFactory] to create [Transition] instances
+     * Returns the [TransitionFactory] to create [SceneTransition] instances
      * for this Activity.
      *
      * By default, this returns a [DefaultTransitionFactory].

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/AcornActivity.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/AcornActivity.kt
@@ -32,7 +32,7 @@ import com.nhaarman.acorn.android.presentation.SceneViewControllerFactory
 import com.nhaarman.acorn.android.presentation.ViewController
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
 import com.nhaarman.acorn.android.transition.DefaultTransitionFactory
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.transition.TransitionFactory
 import com.nhaarman.acorn.navigation.Navigator
 import com.nhaarman.acorn.presentation.Scene
@@ -69,7 +69,7 @@ abstract class AcornActivity : Activity() {
     }
 
     /**
-     * Returns the [TransitionFactory] to create [Transition] instances
+     * Returns the [TransitionFactory] to create [SceneTransition] instances
      * for this Activity.
      *
      * By default, this returns a [DefaultTransitionFactory].

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/DefaultTransitionFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/DefaultTransitionFactory.kt
@@ -27,7 +27,7 @@ import com.nhaarman.acorn.presentation.Scene
 class DefaultTransitionFactory(private val viewControllerFactory: ViewControllerFactory) :
     TransitionFactory {
 
-    override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Transition {
+    override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition {
         return when (data?.isBackwards) {
             true -> FadeOutToBottomTransition { parent ->
                 viewControllerFactory.viewControllerFor(newScene, parent)

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/DoBeforeTransition.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/DoBeforeTransition.kt
@@ -19,8 +19,8 @@ package com.nhaarman.acorn.android.transition
 import android.view.ViewGroup
 
 /**
- * A [Transition] implementation that can execute an action before a delegate
- * Transition is executed.
+ * A [SceneTransition] implementation that can execute an action before a delegate
+ * SceneTransition is executed.
  *
  * This can be used to hide the keyboard before the transition starts, for
  * example.
@@ -28,29 +28,29 @@ import android.view.ViewGroup
  * @see [doOnStart]
  */
 class DoBeforeTransition private constructor(
-    private val delegate: Transition,
+    private val delegate: SceneTransition,
     private val action: (ViewGroup) -> Unit
-) : Transition {
+) : SceneTransition {
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         action(parent)
         delegate.execute(parent, callback)
     }
 
     companion object {
 
-        fun create(delegate: Transition, action: (parent: ViewGroup) -> Unit): DoBeforeTransition {
+        fun create(delegate: SceneTransition, action: (parent: ViewGroup) -> Unit): DoBeforeTransition {
             return DoBeforeTransition(delegate, action)
         }
     }
 }
 
 /**
- * Returns a [Transition] that runs [action] before the receiving Transition
+ * Returns a [SceneTransition] that runs [action] before the receiving SceneTransition
  * instance is started.
  *
  * @param action The action to run.
  */
-fun Transition.doOnStart(action: (parent: ViewGroup) -> Unit): Transition {
+fun SceneTransition.doOnStart(action: (parent: ViewGroup) -> Unit): SceneTransition {
     return DoBeforeTransition.create(this, action)
 }

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/FadeInFromBottomTransition.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/FadeInFromBottomTransition.kt
@@ -32,9 +32,9 @@ import com.nhaarman.acorn.android.transition.internal.doOnPreDraw
  */
 class FadeInFromBottomTransition(
     private val viewController: (ViewGroup) -> ViewController
-) : Transition {
+) : SceneTransition {
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         val originalChildren = (0..parent.childCount).map { parent.getChildAt(it) }
 
         val newViewResult = viewController(parent)

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/FadeOutToBottomTransition.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/FadeOutToBottomTransition.kt
@@ -27,7 +27,7 @@ import com.nhaarman.acorn.android.transition.internal.doOnPreDraw
 import com.nhaarman.acorn.presentation.Scene
 
 /**
- * A [Transition] that fades the current [View] out to bottom, revealing the new
+ * A [SceneTransition] that fades the current [View] out to bottom, revealing the new
  * View underneath.
  *
  * This class assumes there is currently a single View present in the parent
@@ -39,9 +39,9 @@ import com.nhaarman.acorn.presentation.Scene
  */
 class FadeOutToBottomTransition(
     private val viewController: (ViewGroup) -> ViewController
-) : Transition {
+) : SceneTransition {
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         // We're assuming a single View is present.
         val originalChildren = (0..parent.childCount).map { parent.getChildAt(it) }
         val originalView = originalChildren.firstOrNull()

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/HideKeyboard.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/HideKeyboard.kt
@@ -22,14 +22,14 @@ import android.view.inputmethod.InputMethodManager
 import com.nhaarman.acorn.presentation.Scene
 
 /**
- * Returns a new [Transition] instance that hides the keyboard before the
- * receiving Transition is invoked.
+ * Returns a new [SceneTransition] instance that hides the keyboard before the
+ * receiving SceneTransition is invoked.
  */
-fun Transition.hideKeyboardOnStart(): Transition {
+fun SceneTransition.hideKeyboardOnStart(): SceneTransition {
     return doOnStart(hideKeyboard)
 }
 
-fun ((Scene<*>) -> Transition).hideKeyboardOnStart(): (Scene<*>) -> Transition {
+fun ((Scene<*>) -> SceneTransition).hideKeyboardOnStart(): (Scene<*>) -> SceneTransition {
     return { scene: Scene<*> -> invoke(scene).doOnStart(hideKeyboard) }
 }
 

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/TransitionFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/TransitionFactory.kt
@@ -20,17 +20,17 @@ import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Scene
 
 /**
- * An interface that can create [Transition] instances to animate transitions
+ * An interface that can create [SceneTransition] instances to animate transitions
  * between [Scene]s.
  */
 interface TransitionFactory {
 
     /**
-     * Creates a new [Transition] for given [Scene]s.
+     * Creates a new [SceneTransition] for given [Scene]s.
      *
      * @param previousScene The Scene to start the animation from.
      * @param newScene The Scene to animate to.
      * @param data Optional data for the transition.
      */
-    fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Transition
+    fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition
 }

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/TransitionFactoryDSL.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/TransitionFactoryDSL.kt
@@ -40,7 +40,7 @@ fun transitionFactory(
 
 /**
  * A DSL that can create [TransitionFactory] instances by binding pairs of Scenes
- * to [Transition] instances.
+ * to [SceneTransition] instances.
  *
  * @param viewControllerFactory The [ViewControllerFactory] instance to use for
  * layout inflation for fallback transition animations.
@@ -52,27 +52,27 @@ class TransitionFactoryBuilder internal constructor(
     private val bindings = mutableListOf<TransitionBinding>()
 
     /**
-     * Binds two [SceneKey]s to a [Transition] instance.
+     * Binds two [SceneKey]s to a [SceneTransition] instance.
      */
-    infix fun Pair<SceneKey, SceneKey>.use(transition: Transition) {
+    infix fun Pair<SceneKey, SceneKey>.use(transition: SceneTransition) {
         bindings += KeyBinding(first, second, transition)
     }
 
     /**
-     * Binds two [Scene] classes to a [Transition] instance.
+     * Binds two [Scene] classes to a [SceneTransition] instance.
      */
     @JvmName("useWithClasses")
-    infix fun Pair<KClass<out Scene<*>>, KClass<out Scene<*>>>.use(transition: Transition) {
+    infix fun Pair<KClass<out Scene<*>>, KClass<out Scene<*>>>.use(transition: SceneTransition) {
         bindings += ClassBinding(first, second, transition)
     }
 
     /**
-     * Binds two [Scene] classes to a lazily evaluated [Transition] instance.
+     * Binds two [Scene] classes to a lazily evaluated [SceneTransition] instance.
      *
-     * @param transition A function that provides a [Transition] instance. Its
-     * parameter is the destination [Scene] of the Transition.
+     * @param transition A function that provides a [SceneTransition] instance. Its
+     * parameter is the destination [Scene] of the SceneTransition.
      */
-    infix fun Pair<KClass<out Scene<*>>, KClass<out Scene<*>>>.use(transition: (Scene<*>) -> Transition) {
+    infix fun Pair<KClass<out Scene<*>>, KClass<out Scene<*>>>.use(transition: (Scene<*>) -> SceneTransition) {
         bindings += LazyClassBinding(first, second, transition)
     }
 

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/BindingTransitionFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/BindingTransitionFactory.kt
@@ -18,7 +18,7 @@ package com.nhaarman.acorn.android.transition.internal
 
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
 import com.nhaarman.acorn.android.transition.DefaultTransitionFactory
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.transition.TransitionFactory
 import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Scene
@@ -30,7 +30,7 @@ internal class BindingTransitionFactory(
 
     private val delegate by lazy { DefaultTransitionFactory(viewControllerFactory) }
 
-    override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Transition {
+    override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition {
         return bindings
             .mapNotNull { it.transitionFor(previousScene, newScene, data) }
             .firstOrNull()

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/TransitionBinding.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/TransitionBinding.kt
@@ -16,7 +16,7 @@
 
 package com.nhaarman.acorn.android.transition.internal
 
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Scene
 import com.nhaarman.acorn.presentation.SceneKey
@@ -24,16 +24,16 @@ import kotlin.reflect.KClass
 
 internal interface TransitionBinding {
 
-    fun transitionFor(fromScene: Scene<*>, toScene: Scene<*>, data: TransitionData?): Transition?
+    fun transitionFor(fromScene: Scene<*>, toScene: Scene<*>, data: TransitionData?): SceneTransition?
 }
 
 internal class KeyBinding(
     private val fromKey: SceneKey,
     private val toKey: SceneKey,
-    private val transition: Transition
+    private val transition: SceneTransition
 ) : TransitionBinding {
 
-    override fun transitionFor(fromScene: Scene<*>, toScene: Scene<*>, data: TransitionData?): Transition? {
+    override fun transitionFor(fromScene: Scene<*>, toScene: Scene<*>, data: TransitionData?): SceneTransition? {
         if (fromScene.key != fromKey) return null
         if (toScene.key != toKey) return null
 
@@ -48,10 +48,10 @@ internal class KeyBinding(
 internal class ClassBinding(
     private val fromClass: KClass<out Scene<*>>,
     private val toClass: KClass<out Scene<*>>,
-    private val transition: Transition
+    private val transition: SceneTransition
 ) : TransitionBinding {
 
-    override fun transitionFor(fromScene: Scene<*>, toScene: Scene<*>, data: TransitionData?): Transition? {
+    override fun transitionFor(fromScene: Scene<*>, toScene: Scene<*>, data: TransitionData?): SceneTransition? {
         if (fromScene::class != fromClass) return null
         if (toScene::class != toClass) return null
 
@@ -66,10 +66,10 @@ internal class ClassBinding(
 internal class LazyClassBinding(
     private val fromClass: KClass<out Scene<*>>,
     private val toClass: KClass<out Scene<*>>,
-    private val transition: (Scene<*>) -> Transition
+    private val transition: (Scene<*>) -> SceneTransition
 ) : TransitionBinding {
 
-    override fun transitionFor(fromScene: Scene<*>, toScene: Scene<*>, data: TransitionData?): Transition? {
+    override fun transitionFor(fromScene: Scene<*>, toScene: Scene<*>, data: TransitionData?): SceneTransition? {
         if (fromScene::class != fromClass) return null
         if (toScene::class != toClass) return null
 

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/uistate/UIState.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/uistate/UIState.kt
@@ -22,7 +22,7 @@ import com.nhaarman.acorn.android.internal.v
 import com.nhaarman.acorn.android.internal.w
 import com.nhaarman.acorn.android.presentation.ViewController
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.transition.TransitionFactory
 import com.nhaarman.acorn.android.uistate.internal.Destination
 import com.nhaarman.acorn.navigation.TransitionData
@@ -100,7 +100,7 @@ sealed class UIState {
          * @param root The [ViewGroup] to show Scene views in, usually
          * [android.R.id.content].
          * @param transitionFactory a [TransitionFactory] that provides
-         * [Transition] instances for transition animations.
+         * [SceneTransition] instances for transition animations.
          */
         fun create(
             root: ViewGroup,
@@ -440,7 +440,7 @@ internal class VisibleWithDestination(
         }
     }
 
-    private interface CancellableTransitionCallback : Transition.Callback {
+    private interface CancellableTransitionCallback : SceneTransition.Callback {
 
         fun cancel()
     }

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/util/TestTransition.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/util/TestTransition.kt
@@ -18,17 +18,17 @@ package com.nhaarman.acorn.android.util
 
 import android.view.ViewGroup
 import com.nhaarman.acorn.android.presentation.ViewController
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 
-class TestTransition : Transition {
+class TestTransition : SceneTransition {
 
-    private var callback: Transition.Callback? = null
+    private var callback: SceneTransition.Callback? = null
         set(value) {
-            if (field != null) error("Transition already executed")
+            if (field != null) error("SceneTransition already executed")
             field = value
         }
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         this.callback = callback
     }
 

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/util/TestTransitionFactory.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/util/TestTransitionFactory.kt
@@ -16,16 +16,16 @@
 
 package com.nhaarman.acorn.android.util
 
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.transition.TransitionFactory
 import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Scene
 
 class TestTransitionFactory : TransitionFactory {
 
-    val transitions = mutableMapOf<Pair<Scene<*>, Scene<*>>, Transition>()
+    val transitions = mutableMapOf<Pair<Scene<*>, Scene<*>>, SceneTransition>()
 
-    override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Transition {
+    override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition {
         return transitions[previousScene to newScene]!!
     }
 }

--- a/samples/hello-concurrentpairnavigator/src/main/java/com/nhaarman/acorn/samples/helloconcurrentpairnavigator/FirstSecondTransition.kt
+++ b/samples/hello-concurrentpairnavigator/src/main/java/com/nhaarman/acorn/samples/helloconcurrentpairnavigator/FirstSecondTransition.kt
@@ -18,15 +18,15 @@ package com.nhaarman.acorn.samples.helloconcurrentpairnavigator
 
 import android.view.ViewGroup
 import androidx.core.view.doOnPreDraw
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.util.inflateView
 import com.nhaarman.acorn.navigation.experimental.ExperimentalConcurrentPairNavigator
 import kotlinx.android.synthetic.main.second_scene.view.*
 
 @UseExperimental(ExperimentalConcurrentPairNavigator::class)
-object FirstSecondTransition : Transition {
+object FirstSecondTransition : SceneTransition {
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         val secondScene = parent.inflateView(R.layout.second_scene)
         parent.addView(secondScene)
 

--- a/samples/hello-concurrentpairnavigator/src/main/java/com/nhaarman/acorn/samples/helloconcurrentpairnavigator/SecondFirstTransition.kt
+++ b/samples/hello-concurrentpairnavigator/src/main/java/com/nhaarman/acorn/samples/helloconcurrentpairnavigator/SecondFirstTransition.kt
@@ -17,14 +17,14 @@
 package com.nhaarman.acorn.samples.helloconcurrentpairnavigator
 
 import android.view.ViewGroup
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import kotlinx.android.synthetic.main.first_and_second_scene.view.*
 import kotlinx.android.synthetic.main.first_scene.view.*
 import kotlinx.android.synthetic.main.second_scene.view.*
 
-object SecondFirstTransition : Transition {
+object SecondFirstTransition : SceneTransition {
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         val firstAndSecondRoot = parent.findViewById<ViewGroup>(R.id.firstAndSecondRoot)
 
         if (firstAndSecondRoot != null) {

--- a/samples/hello-transitionanimation/src/main/java/com/nhaarman/acorn/samples/hellotransitionanimation/FirstToSecondTransition.kt
+++ b/samples/hello-transitionanimation/src/main/java/com/nhaarman/acorn/samples/hellotransitionanimation/FirstToSecondTransition.kt
@@ -19,11 +19,11 @@ package com.nhaarman.acorn.samples.hellotransitionanimation
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.doOnPreDraw
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 
-object FirstToSecondTransition : Transition {
+object FirstToSecondTransition : SceneTransition {
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         val currentLayout = parent.getChildAt(0)
 
         val newLayout = LayoutInflater.from(parent.context).inflate(R.layout.second_scene, parent, false)

--- a/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/ui/transition/EditItemItemListTransition.kt
+++ b/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/ui/transition/EditItemItemListTransition.kt
@@ -22,7 +22,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.doOnPreDraw
 import com.nhaarman.acorn.android.transition.FadeOutToBottomTransition
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.util.inflate
 import com.nhaarman.acorn.notesapp.android.R
 import com.nhaarman.acorn.notesapp.android.ui.itemlist.ItemListViewController
@@ -34,9 +34,9 @@ import kotlinx.android.synthetic.main.edititem_scene.view.*
  *
  * This uses the [View.tag] property to temporarily store coordinate information.
  */
-object EditItemItemListTransition : Transition {
+object EditItemItemListTransition : SceneTransition {
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         val editItemLayout = parent.getChildAt(0)
         val clickedItemViewData = editItemLayout.tag as? ClickedItemViewData
 

--- a/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/ui/transition/ItemListCreateItemTransition.kt
+++ b/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/ui/transition/ItemListCreateItemTransition.kt
@@ -19,19 +19,19 @@ package com.nhaarman.acorn.notesapp.android.ui.transition
 import android.view.ViewAnimationUtils
 import android.view.ViewGroup
 import androidx.core.animation.addListener
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.util.inflateView
 import com.nhaarman.acorn.notesapp.android.R
 import com.nhaarman.acorn.notesapp.android.ui.createitem.CreateItemViewController
 import kotlinx.android.synthetic.main.itemlist_scene.view.*
 
 /**
- * A [Transition] that shows a circular reveal animation to transition from
+ * A [SceneTransition] that shows a circular reveal animation to transition from
  * the ItemList layout to the CreateItem layout.
  */
-object ItemListCreateItemTransition : Transition {
+object ItemListCreateItemTransition : SceneTransition {
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         val itemListLayout = parent.getChildAt(0)
         val view = parent.inflateView(R.layout.itemlistcreateitem_reveal)
         parent.addView(view)

--- a/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/ui/transition/ItemListEditItemTransition.kt
+++ b/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/ui/transition/ItemListEditItemTransition.kt
@@ -22,7 +22,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.doOnPreDraw
 import com.nhaarman.acorn.android.transition.FadeInFromBottomTransition
-import com.nhaarman.acorn.android.transition.Transition
+import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.util.inflate
 import com.nhaarman.acorn.notesapp.android.R
 import com.nhaarman.acorn.notesapp.android.ui.edititem.EditItemViewController
@@ -32,9 +32,9 @@ import kotlinx.android.synthetic.main.itemlist_scene.view.*
 /**
  * Shows a 'shared element transition' that originates from the clicked view.
  */
-object ItemListEditItemTransition : Transition {
+object ItemListEditItemTransition : SceneTransition {
 
-    override fun execute(parent: ViewGroup, callback: Transition.Callback) {
+    override fun execute(parent: ViewGroup, callback: SceneTransition.Callback) {
         val itemListLayout = parent.getChildAt(0)
         val itemsRecyclerView = itemListLayout.itemsRecyclerView
         val clickedView = itemsRecyclerView.clickedView


### PR DESCRIPTION
The 'Transition' name clashes with Android's
`android.transition.Transition`.

Fixes #118 