### PR TITLE
Introduce the experimental AcornEvents API

### DIFF
--- a/ext/acorn-android/build.gradle
+++ b/ext/acorn-android/build.gradle
@@ -49,3 +49,9 @@ task install(type: Copy) {
 androidExtensions {
     experimental = true
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs = ["-Xuse-experimental=kotlin.Experimental"]
+    }
+}

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/AcornSceneDispatcher.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/AcornSceneDispatcher.kt
@@ -39,6 +39,10 @@ import com.nhaarman.acorn.state.SavedState
 import com.nhaarman.acorn.state.get
 import com.nhaarman.acorn.state.savedState
 
+/**
+ * A default [SceneDispatcher] implementation that utilizes a [UIHandler] and
+ * an [ActivityHandler] to dispatch [Scene]s.
+ */
 class AcornSceneDispatcher internal constructor(
     private val context: Context,
     private val viewControllerFactory: ViewControllerFactory,
@@ -46,7 +50,7 @@ class AcornSceneDispatcher internal constructor(
     private val uiHandler: UIHandler,
     private val activityHandler: ActivityHandler,
     private val callback: Callback
-) {
+) : SceneDispatcher {
 
     private var listener: MyListener? = null
         set(value) {
@@ -55,24 +59,24 @@ class AcornSceneDispatcher internal constructor(
         }
 
     @CheckResult
-    fun dispatchScenesFor(navigator: Navigator): DisposableHandle {
+    override fun dispatchScenesFor(navigator: Navigator): DisposableHandle {
         val listener = MyListener().also { this.listener = it }
         return navigator.addNavigatorEventsListener(listener)
     }
 
-    fun onUIVisible() {
+    override fun onUIVisible() {
         uiHandler.onUIVisible()
     }
 
-    fun onUINotVisible() {
+    override fun onUINotVisible() {
         uiHandler.onUINotVisible()
     }
 
-    fun onActivityResult(resultCode: Int, data: Intent?) {
+    override fun onActivityResult(resultCode: Int, data: Intent?) {
         activityHandler.onActivityResult(resultCode, data)
     }
 
-    fun saveInstanceState(): SavedState {
+    override fun saveInstanceState(): SavedState {
         return savedState {
             it.activityHandlerState = activityHandler.saveInstanceState()
         }

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/SceneDispatcher.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/SceneDispatcher.kt
@@ -1,0 +1,65 @@
+/*
+ *    Copyright 2018 Niek Haarman
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.nhaarman.acorn.android.dispatching
+
+import android.app.Activity
+import android.content.Intent
+import androidx.annotation.CheckResult
+import com.nhaarman.acorn.navigation.DisposableHandle
+import com.nhaarman.acorn.navigation.Navigator
+import com.nhaarman.acorn.presentation.Scene
+import com.nhaarman.acorn.state.SavedState
+
+/**
+ * A [SceneDispatcher] is responsible for bridging between [Activity] instances
+ * and the [Navigator], handling changes of [Scene] instances, and ensuring the
+ * UI is properly updated.
+ */
+interface SceneDispatcher {
+
+    /**
+     * Starts dispatching the [Scene] instances for given [navigator].
+     *
+     * By disposing the resulting [DisposableHandle] one can stop the
+     * dispatching.
+     */
+    @CheckResult
+    fun dispatchScenesFor(navigator: Navigator): DisposableHandle
+
+    /**
+     * To be invoked when the application's UI becomes visible to the user.
+     * A good place to invoke this would be in [Activity.onStart].
+     */
+    fun onUIVisible()
+
+    /**
+     * To be invoked when the application's UI becomes invisible to the user.
+     * A good place to invoke this would be in [Activity.onStop].
+     */
+    fun onUINotVisible()
+
+    /**
+     * To be invoked when the [Activity] receives an invocation to its
+     * [Activity.onActivityResult] method.
+     */
+    fun onActivityResult(resultCode: Int, data: Intent?)
+
+    /**
+     * Saves any state for this [SceneDispatcher].
+     */
+    fun saveInstanceState(): SavedState
+}

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/SceneDispatcherFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/SceneDispatcherFactory.kt
@@ -14,15 +14,8 @@
  *    limitations under the License.
  */
 
-package com.nhaarman.acorn.navigation
+package com.nhaarman.acorn.android.dispatching
 
-import com.nhaarman.acorn.state.NavigatorState
+import com.nhaarman.acorn.state.SavedState
 
-/**
- * Indicates that implementers can have their instance state saved.
- */
-interface SavableNavigator : Navigator {
-
-    /** Save instance state. */
-    fun saveInstanceState(): NavigatorState
-}
+typealias SceneDispatcherFactory = (savedState: SavedState?) -> SceneDispatcher

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/internal/DefaultActivityHandler.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/internal/DefaultActivityHandler.kt
@@ -63,8 +63,11 @@ internal class DefaultActivityHandler(
     }
 
     override fun withoutScene() {
-        d("ActivityHandler", "Scene lost.")
-        lastScene = null
+        if (lastSceneKey != null) {
+            d("ActivityHandler", "Scene lost.")
+            lastScene = null
+            lastSceneKey = null
+        }
     }
 
     override fun onActivityResult(resultCode: Int, data: Intent?) {

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/experimental/AcornEvents.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/experimental/AcornEvents.kt
@@ -1,0 +1,76 @@
+/*
+ *    Copyright 2018 Niek Haarman
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.nhaarman.acorn.android.experimental
+
+import com.nhaarman.acorn.android.navigation.NavigatorProvider
+import com.nhaarman.acorn.navigation.DisposableHandle
+import com.nhaarman.acorn.navigation.Navigator
+
+/**
+ * An experimental class to provide hooks for Acorn.
+ */
+@ExperimentalAcornEvents
+object AcornEvents {
+
+    private var dispatchingListeners = listOf<DispatchingListener>()
+
+    fun registerDispatchingListener(listener: DispatchingListener): DisposableHandle {
+        dispatchingListeners += listener
+        return object : DisposableHandle {
+
+            override fun dispose() {
+                dispatchingListeners -= listener
+            }
+
+            override fun isDisposed(): Boolean {
+                return listener in dispatchingListeners
+            }
+        }
+    }
+
+    fun onStartDispatching(navigatorProvider: NavigatorProvider, instance: Navigator) {
+        dispatchingListeners.forEach { it.onStartDispatching(navigatorProvider, instance) }
+    }
+
+    fun onStopDispatching(navigatorProvider: NavigatorProvider, instance: Navigator) {
+        dispatchingListeners.forEach { it.onStopDispatching(navigatorProvider, instance) }
+    }
+
+    interface DispatchingListener {
+
+        /**
+         * Called when a component starts dispatching Scenes for given [instance].
+         *
+         * @param navigatorProvider The [NavigatorProvider] that provides the
+         * Navigator [instance].
+         * @param instance The [Navigator] instance that provides the Scenes to
+         * be dispatched.
+         */
+        fun onStartDispatching(navigatorProvider: NavigatorProvider, instance: Navigator)
+
+        /**
+         * Called when the component that started dispatching Scenes for given
+         * [instance] stops dispatching.
+         *
+         * @param navigatorProvider The [NavigatorProvider] that provides the
+         * Navigator [instance].
+         * @param instance The [Navigator] instance that provided the Scenes to
+         * be dispatched.
+         */
+        fun onStopDispatching(navigatorProvider: NavigatorProvider, instance: Navigator)
+    }
+}

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/experimental/ExperimentalAcornEvents.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/experimental/ExperimentalAcornEvents.kt
@@ -14,15 +14,16 @@
  *    limitations under the License.
  */
 
-package com.nhaarman.acorn.navigation
-
-import com.nhaarman.acorn.state.NavigatorState
+package com.nhaarman.acorn.android.experimental
 
 /**
- * Indicates that implementers can have their instance state saved.
+ * Marks all [AcornEvents] declarations as an experimental API to
+ * indicate that it is still experimental.
+ *
+ * The AcornEvents class has no backward compatibility guarantees
+ * whatsoever.
  */
-interface SavableNavigator : Navigator {
-
-    /** Save instance state. */
-    fun saveInstanceState(): NavigatorState
-}
+@Experimental
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class ExperimentalAcornEvents

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/experimental/HookingSceneDispatcher.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/experimental/HookingSceneDispatcher.kt
@@ -1,0 +1,63 @@
+/*
+ *    Copyright 2018 Niek Haarman
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.nhaarman.acorn.android.experimental
+
+import com.nhaarman.acorn.android.dispatching.SceneDispatcher
+import com.nhaarman.acorn.android.navigation.NavigatorProvider
+import com.nhaarman.acorn.navigation.DisposableHandle
+import com.nhaarman.acorn.navigation.Navigator
+
+/**
+ * A [SceneDispatcher] that wraps an existing instance, notifying the
+ * experimental [AcornEvents] class of dispatching events.
+ */
+@UseExperimental(ExperimentalAcornEvents::class)
+class HookingSceneDispatcher private constructor(
+    private val delegate: SceneDispatcher,
+    private val navigatorProvider: NavigatorProvider
+) : SceneDispatcher by delegate {
+
+    override fun dispatchScenesFor(navigator: Navigator): DisposableHandle {
+        AcornEvents.onStartDispatching(navigatorProvider, navigator)
+        val original = delegate.dispatchScenesFor(navigator)
+
+        return object : DisposableHandle {
+
+            override fun dispose() {
+                AcornEvents.onStopDispatching(navigatorProvider, navigator)
+                original.dispose()
+            }
+
+            override fun isDisposed(): Boolean {
+                return original.isDisposed()
+            }
+        }
+    }
+
+    companion object {
+
+        fun create(
+            delegate: SceneDispatcher,
+            navigatorProvider: NavigatorProvider
+        ): HookingSceneDispatcher {
+            return HookingSceneDispatcher(
+                delegate,
+                navigatorProvider
+            )
+        }
+    }
+}

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/navigation/AbstractNavigatorProvider.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/navigation/AbstractNavigatorProvider.kt
@@ -60,7 +60,7 @@ abstract class AbstractNavigatorProvider<N : Navigator> : NavigatorProvider {
         return createNavigator(null)
     }
 
-    abstract fun createNavigator(savedState: NavigatorState?): N
+    protected abstract fun createNavigator(savedState: NavigatorState?): N
 
     override fun saveNavigatorState(): NavigatorState? {
         return navigatorState {


### PR DESCRIPTION
`AcornEvents` can be used as a basis to provide hooks into Acorn. This first implementation allows a hook registration to be notified when a Navigator's scenes start and stop dispatching.