### PR TITLE
Include a 'supports' method in SceneTransitionFactory

### DIFF
--- a/ext/acorn-android/acorn-android-appcompat/src/main/java/com/nhaarman/acorn/android/AcornAppCompatActivity.kt
+++ b/ext/acorn-android/acorn-android-appcompat/src/main/java/com/nhaarman/acorn/android/AcornAppCompatActivity.kt
@@ -31,9 +31,11 @@ import com.nhaarman.acorn.android.presentation.NoopViewControllerFactory
 import com.nhaarman.acorn.android.presentation.SceneViewControllerFactory
 import com.nhaarman.acorn.android.presentation.ViewController
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.DefaultTransitionFactory
+import com.nhaarman.acorn.android.transition.ComposingSceneTransitionFactory
+import com.nhaarman.acorn.android.transition.DefaultSceneTransitionFactory
+import com.nhaarman.acorn.android.transition.NoopSceneTransitionFactory
 import com.nhaarman.acorn.android.transition.SceneTransition
-import com.nhaarman.acorn.android.transition.TransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.navigation.Navigator
 import com.nhaarman.acorn.presentation.Scene
 
@@ -69,16 +71,17 @@ abstract class AcornAppCompatActivity : AppCompatActivity() {
     }
 
     /**
-     * Returns the [TransitionFactory] to create [SceneTransition] instances
-     * for this Activity.
+     * Returns the [SceneTransitionFactory] to create [SceneTransition] instances
+     * for this Activity. The resulting factory instance will be combined with
+     * a [DefaultSceneTransitionFactory] as fallback.
      *
-     * By default, this returns a [DefaultTransitionFactory].
+     * By default, this returns a [NoopSceneTransitionFactory].
      *
      * @param viewControllerFactory The [ViewControllerFactory] as returned by
      * [provideViewControllerFactory].
      */
-    protected open fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): TransitionFactory {
-        return DefaultTransitionFactory(viewControllerFactory)
+    protected open fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): SceneTransitionFactory {
+        return NoopSceneTransitionFactory
     }
 
     /**
@@ -107,8 +110,11 @@ abstract class AcornAppCompatActivity : AppCompatActivity() {
         )
     }
 
-    private val transitionFactory: TransitionFactory by lazy {
-        provideTransitionFactory(viewControllerFactory)
+    private val transitionFactory: SceneTransitionFactory by lazy {
+        ComposingSceneTransitionFactory.from(
+            provideTransitionFactory(viewControllerFactory),
+            DefaultSceneTransitionFactory(viewControllerFactory)
+        )
     }
 
     private val activityControllerFactory: ActivityControllerFactory by lazy {

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/AcornActivity.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/AcornActivity.kt
@@ -31,9 +31,11 @@ import com.nhaarman.acorn.android.presentation.NoopViewControllerFactory
 import com.nhaarman.acorn.android.presentation.SceneViewControllerFactory
 import com.nhaarman.acorn.android.presentation.ViewController
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.DefaultTransitionFactory
+import com.nhaarman.acorn.android.transition.ComposingSceneTransitionFactory
+import com.nhaarman.acorn.android.transition.DefaultSceneTransitionFactory
+import com.nhaarman.acorn.android.transition.NoopSceneTransitionFactory
 import com.nhaarman.acorn.android.transition.SceneTransition
-import com.nhaarman.acorn.android.transition.TransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.navigation.Navigator
 import com.nhaarman.acorn.presentation.Scene
 
@@ -69,16 +71,17 @@ abstract class AcornActivity : Activity() {
     }
 
     /**
-     * Returns the [TransitionFactory] to create [SceneTransition] instances
-     * for this Activity.
+     * Returns the [SceneTransitionFactory] to create [SceneTransition] instances
+     * for this Activity. The resulting factory instance will be combined with
+     * a [DefaultSceneTransitionFactory] as fallback.
      *
-     * By default, this returns a [DefaultTransitionFactory].
+     * By default, this returns a [NoopSceneTransitionFactory].
      *
      * @param viewControllerFactory The [ViewControllerFactory] as returned by
      * [provideViewControllerFactory].
      */
-    protected open fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): TransitionFactory {
-        return DefaultTransitionFactory(viewControllerFactory)
+    protected open fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): SceneTransitionFactory {
+        return NoopSceneTransitionFactory
     }
 
     /**
@@ -107,8 +110,11 @@ abstract class AcornActivity : Activity() {
         )
     }
 
-    private val transitionFactory: TransitionFactory by lazy {
-        provideTransitionFactory(viewControllerFactory)
+    private val transitionFactory: SceneTransitionFactory by lazy {
+        ComposingSceneTransitionFactory.from(
+            provideTransitionFactory(viewControllerFactory),
+            DefaultSceneTransitionFactory(viewControllerFactory)
+        )
     }
 
     private val activityControllerFactory: ActivityControllerFactory by lazy {

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/AcornActivityDelegate.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/AcornActivityDelegate.kt
@@ -34,9 +34,9 @@ import com.nhaarman.acorn.android.presentation.ActivityControllerFactory
 import com.nhaarman.acorn.android.presentation.NoopActivityControllerFactory
 import com.nhaarman.acorn.android.presentation.ViewController
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.DefaultTransitionFactory
+import com.nhaarman.acorn.android.transition.DefaultSceneTransitionFactory
 import com.nhaarman.acorn.android.transition.SceneTransition
-import com.nhaarman.acorn.android.transition.TransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.android.util.toBundle
 import com.nhaarman.acorn.android.util.toNavigatorState
 import com.nhaarman.acorn.navigation.DisposableHandle
@@ -142,16 +142,16 @@ class AcornActivityDelegate private constructor(
          * @param activityControllerFactory The [ActivityControllerFactory]
          * instance that is used to create [ActivityController] instances when
          * dispatching Scenes. Defaults to [NoopActivityControllerFactory].
-         * @param transitionFactory the [TransitionFactory] instance that is
+         * @param transitionFactory the [SceneTransitionFactory] instance that is
          * used to create [SceneTransition] instances when animating Scene
-         * transitions. Defaults to [DefaultTransitionFactory].
+         * transitions. Defaults to [DefaultSceneTransitionFactory].
          */
         fun from(
             activity: Activity,
             navigatorProvider: NavigatorProvider,
             viewControllerFactory: ViewControllerFactory,
             activityControllerFactory: ActivityControllerFactory = NoopActivityControllerFactory,
-            transitionFactory: TransitionFactory = DefaultTransitionFactory(viewControllerFactory)
+            transitionFactory: SceneTransitionFactory = DefaultSceneTransitionFactory(viewControllerFactory)
         ): AcornActivityDelegate {
             return AcornActivityDelegate.from(
                 activity,
@@ -179,9 +179,9 @@ class AcornActivityDelegate private constructor(
          * @param activityControllerFactory The [ActivityControllerFactory]
          * instance that is used to create [ActivityController] instances when
          * dispatching Scenes. Defaults to [NoopActivityControllerFactory].
-         * @param transitionFactory the [TransitionFactory] instance that is
+         * @param transitionFactory the [SceneTransitionFactory] instance that is
          * used to create [SceneTransition] instances when animating Scene
-         * transitions. Defaults to [DefaultTransitionFactory].
+         * transitions. Defaults to [DefaultSceneTransitionFactory].
          */
         @UseExperimental(ExperimentalAcornEvents::class)
         fun from(
@@ -190,7 +190,7 @@ class AcornActivityDelegate private constructor(
             navigatorProvider: NavigatorProvider,
             viewControllerFactory: ViewControllerFactory,
             activityControllerFactory: ActivityControllerFactory = NoopActivityControllerFactory,
-            transitionFactory: TransitionFactory = DefaultTransitionFactory(viewControllerFactory)
+            transitionFactory: SceneTransitionFactory = DefaultSceneTransitionFactory(viewControllerFactory)
         ): AcornActivityDelegate {
             return AcornActivityDelegate.from(
                 HookingSceneDispatcherFactory(
@@ -225,7 +225,7 @@ class AcornActivityDelegate private constructor(
         private val navigatorProvider: NavigatorProvider,
         private val viewControllerFactory: ViewControllerFactory,
         private val activityControllerFactory: ActivityControllerFactory,
-        private val transitionFactory: TransitionFactory
+        private val transitionFactory: SceneTransitionFactory
     ) : SceneDispatcherFactory {
 
         override fun invoke(savedState: SavedState?): SceneDispatcher {

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/AcornSceneDispatcher.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/AcornSceneDispatcher.kt
@@ -27,7 +27,7 @@ import com.nhaarman.acorn.android.internal.contentView
 import com.nhaarman.acorn.android.internal.d
 import com.nhaarman.acorn.android.presentation.ActivityControllerFactory
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.TransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.android.uistate.UIHandler
 import com.nhaarman.acorn.android.uistate.UIStateUIHandler
 import com.nhaarman.acorn.navigation.DisposableHandle
@@ -123,7 +123,7 @@ class AcornSceneDispatcher internal constructor(
             activity: Activity,
             viewControllerFactory: ViewControllerFactory,
             activityControllerFactory: ActivityControllerFactory,
-            transitionFactory: TransitionFactory,
+            transitionFactory: SceneTransitionFactory,
             callback: Callback,
             savedState: SavedState?
         ): AcornSceneDispatcher {
@@ -143,7 +143,7 @@ class AcornSceneDispatcher internal constructor(
             root: ViewGroup,
             viewControllerFactory: ViewControllerFactory,
             activityControllerFactory: ActivityControllerFactory,
-            transitionFactory: TransitionFactory,
+            transitionFactory: SceneTransitionFactory,
             callback: Callback,
             savedState: SavedState?
         ): AcornSceneDispatcher {

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/presentation/ViewControllerFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/presentation/ViewControllerFactory.kt
@@ -48,8 +48,7 @@ interface ViewControllerFactory {
      * itself, but it can use the parent to generate the LayoutParams of the
      * view.
      *
-     * @return The resulting [ViewController]. `null` if no result could be created
-     * for given [scene].
+     * @return The resulting [ViewController].
      */
     fun viewControllerFor(scene: Scene<*>, parent: ViewGroup): ViewController
 }

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/NoopSceneTransitionFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/NoopSceneTransitionFactory.kt
@@ -19,18 +19,13 @@ package com.nhaarman.acorn.android.transition
 import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Scene
 
-/**
- * An interface that can create [SceneTransition] instances to animate transitions
- * between [Scene]s.
- */
-interface TransitionFactory {
+object NoopSceneTransitionFactory : SceneTransitionFactory {
 
-    /**
-     * Creates a new [SceneTransition] for given [Scene]s.
-     *
-     * @param previousScene The Scene to start the animation from.
-     * @param newScene The Scene to animate to.
-     * @param data Optional data for the transition.
-     */
-    fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition
+    override fun supports(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Boolean {
+        return false
+    }
+
+    override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition {
+        error("NoopSceneTransitionFactory can not create SceneTransitions.")
+    }
 }

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/SceneTransitionFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/SceneTransitionFactory.kt
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2018 Niek Haarman
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.nhaarman.acorn.android.transition
+
+import com.nhaarman.acorn.navigation.TransitionData
+import com.nhaarman.acorn.presentation.Scene
+
+/**
+ * An interface that can create [SceneTransition] instances to animate transitions
+ * between [Scene]s.
+ */
+interface SceneTransitionFactory {
+
+    /**
+     * Returns `true` when this SceneTransitionFactory can create a [SceneTransition]
+     * when [transitionFor] is called.
+     * If this method returns false for a specific combination of its parameters,
+     * no calls to [transitionFor] with that combination must be made.
+     */
+    fun supports(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Boolean
+
+    /**
+     * Creates a new [SceneTransition] for given [Scene]s.
+     *
+     * @param previousScene The Scene to start the animation from.
+     * @param newScene The Scene to animate to.
+     * @param data Optional data for the transition.
+     */
+    fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition
+}

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/TransitionFactoryDSL.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/TransitionFactoryDSL.kt
@@ -17,7 +17,7 @@
 package com.nhaarman.acorn.android.transition
 
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.internal.BindingTransitionFactory
+import com.nhaarman.acorn.android.transition.internal.BindingSceneTransitionFactory
 import com.nhaarman.acorn.android.transition.internal.ClassBinding
 import com.nhaarman.acorn.android.transition.internal.KeyBinding
 import com.nhaarman.acorn.android.transition.internal.LazyClassBinding
@@ -27,25 +27,25 @@ import com.nhaarman.acorn.presentation.SceneKey
 import kotlin.reflect.KClass
 
 /**
- * Entry point for the [TransitionFactory] DSL.
+ * Entry point for the [SceneTransitionFactory] DSL.
  *
- * @see [TransitionFactoryBuilder]
+ * @see [SceneTransitionFactoryBuilder]
  */
-fun transitionFactory(
+fun sceneTransitionFactory(
     viewControllerFactory: ViewControllerFactory,
-    init: TransitionFactoryBuilder.() -> Unit
-): TransitionFactory {
-    return TransitionFactoryBuilder(viewControllerFactory).apply(init).build()
+    init: SceneTransitionFactoryBuilder.() -> Unit
+): SceneTransitionFactory {
+    return SceneTransitionFactoryBuilder(viewControllerFactory).apply(init).build()
 }
 
 /**
- * A DSL that can create [TransitionFactory] instances by binding pairs of Scenes
+ * A DSL that can create [SceneTransitionFactory] instances by binding pairs of Scenes
  * to [SceneTransition] instances.
  *
  * @param viewControllerFactory The [ViewControllerFactory] instance to use for
  * layout inflation for fallback transition animations.
  */
-class TransitionFactoryBuilder internal constructor(
+class SceneTransitionFactoryBuilder internal constructor(
     private val viewControllerFactory: ViewControllerFactory
 ) {
 
@@ -76,8 +76,8 @@ class TransitionFactoryBuilder internal constructor(
         bindings += LazyClassBinding(first, second, transition)
     }
 
-    fun build(): TransitionFactory {
-        return BindingTransitionFactory(
+    fun build(): SceneTransitionFactory {
+        return BindingSceneTransitionFactory(
             viewControllerFactory,
             bindings.asSequence()
         )

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/BindingSceneTransitionFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/BindingSceneTransitionFactory.kt
@@ -1,0 +1,43 @@
+/*
+ *    Copyright 2018 Niek Haarman
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.nhaarman.acorn.android.transition.internal
+
+import com.nhaarman.acorn.android.presentation.ViewControllerFactory
+import com.nhaarman.acorn.android.transition.DefaultSceneTransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransition
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
+import com.nhaarman.acorn.navigation.TransitionData
+import com.nhaarman.acorn.presentation.Scene
+
+internal class BindingSceneTransitionFactory(
+    private val viewControllerFactory: ViewControllerFactory,
+    private val bindings: Sequence<TransitionBinding>
+) : SceneTransitionFactory {
+
+    private val delegate by lazy { DefaultSceneTransitionFactory(viewControllerFactory) }
+
+    override fun supports(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Boolean {
+        return true
+    }
+
+    override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition {
+        return bindings
+            .mapNotNull { it.transitionFor(previousScene, newScene, data) }
+            .firstOrNull()
+            ?: delegate.transitionFor(previousScene, newScene, data)
+    }
+}

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/uistate/UIState.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/uistate/UIState.kt
@@ -23,7 +23,7 @@ import com.nhaarman.acorn.android.internal.w
 import com.nhaarman.acorn.android.presentation.ViewController
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
 import com.nhaarman.acorn.android.transition.SceneTransition
-import com.nhaarman.acorn.android.transition.TransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.android.uistate.internal.Destination
 import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Container
@@ -99,12 +99,12 @@ sealed class UIState {
          *
          * @param root The [ViewGroup] to show Scene views in, usually
          * [android.R.id.content].
-         * @param transitionFactory a [TransitionFactory] that provides
+         * @param transitionFactory a [SceneTransitionFactory] that provides
          * [SceneTransition] instances for transition animations.
          */
         fun create(
             root: ViewGroup,
-            transitionFactory: TransitionFactory
+            transitionFactory: SceneTransitionFactory
         ): UIState = NotVisible(root, transitionFactory)
     }
 }
@@ -115,7 +115,7 @@ sealed class UIState {
  */
 internal class NotVisible(
     private val root: ViewGroup,
-    private val transitionFactory: TransitionFactory
+    private val transitionFactory: SceneTransitionFactory
 ) : UIState() {
 
     /**
@@ -154,7 +154,7 @@ internal class NotVisible(
  */
 internal class NotVisibleWithDestination(
     private val root: ViewGroup,
-    private val transitionFactory: TransitionFactory,
+    private val transitionFactory: SceneTransitionFactory,
     private val destination: Destination,
     private val existingViewController: ViewController?
 ) : UIState() {
@@ -233,7 +233,7 @@ internal class NotVisibleWithDestination(
  */
 internal class Visible(
     private val root: ViewGroup,
-    private val transitionFactory: TransitionFactory
+    private val transitionFactory: SceneTransitionFactory
 ) : UIState() {
 
     /**
@@ -288,7 +288,7 @@ internal class Visible(
  */
 internal class VisibleWithDestination(
     private val root: ViewGroup,
-    private val transitionFactory: TransitionFactory,
+    private val transitionFactory: SceneTransitionFactory,
     private var currentDestination: Destination,
     private var currentViewController: ViewController
 ) : UIState() {

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/uistate/UIStateUIHandler.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/uistate/UIStateUIHandler.kt
@@ -20,7 +20,7 @@ import android.app.Activity
 import android.view.ViewGroup
 import com.nhaarman.acorn.android.internal.contentView
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.TransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Container
 import com.nhaarman.acorn.presentation.Scene
@@ -31,7 +31,7 @@ import com.nhaarman.acorn.util.lazyVar
  */
 class UIStateUIHandler private constructor(
     private val root: ViewGroup,
-    private val transitionFactory: TransitionFactory
+    private val transitionFactory: SceneTransitionFactory
 ) : UIHandler {
 
     private var state by lazyVar {
@@ -62,7 +62,7 @@ class UIStateUIHandler private constructor(
 
         fun create(
             root: ViewGroup,
-            transitionFactory: TransitionFactory
+            transitionFactory: SceneTransitionFactory
         ): UIStateUIHandler {
             return UIStateUIHandler(
                 root,
@@ -72,7 +72,7 @@ class UIStateUIHandler private constructor(
 
         fun create(
             activity: Activity,
-            transitionFactory: TransitionFactory
+            transitionFactory: SceneTransitionFactory
         ): UIStateUIHandler {
             return UIStateUIHandler(
                 activity.contentView,

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/uistate/NotVisibleTest.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/uistate/NotVisibleTest.kt
@@ -17,7 +17,7 @@
 package com.nhaarman.acorn.android.uistate
 
 import com.nhaarman.acorn.android.util.RootViewGroup
-import com.nhaarman.acorn.android.util.TestTransitionFactory
+import com.nhaarman.acorn.android.util.TestSceneTransitionFactory
 import com.nhaarman.expect.expect
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
@@ -30,7 +30,7 @@ internal class NotVisibleTest {
 
     val state = NotVisible(
         root,
-        TestTransitionFactory()
+        TestSceneTransitionFactory()
     )
 
     @Test

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/uistate/NotVisibleWithDestinationTest.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/uistate/NotVisibleWithDestinationTest.kt
@@ -19,7 +19,7 @@ package com.nhaarman.acorn.android.uistate
 import com.nhaarman.acorn.android.uistate.internal.Destination
 import com.nhaarman.acorn.android.util.RootViewGroup
 import com.nhaarman.acorn.android.util.TestScene
-import com.nhaarman.acorn.android.util.TestTransitionFactory
+import com.nhaarman.acorn.android.util.TestSceneTransitionFactory
 import com.nhaarman.acorn.android.util.TestView
 import com.nhaarman.acorn.android.util.TestViewController
 import com.nhaarman.acorn.android.util.TestViewControllerFactory
@@ -47,7 +47,7 @@ internal class NotVisibleWithDestinationTest {
 
     val state = NotVisibleWithDestination(
         root,
-        TestTransitionFactory(),
+        TestSceneTransitionFactory(),
         destination,
         null
     )
@@ -121,7 +121,7 @@ internal class NotVisibleWithDestinationTest {
 
         val state = NotVisibleWithDestination(
             root,
-            TestTransitionFactory(),
+            TestSceneTransitionFactory(),
             destination,
             TestViewController(TestView())
         )
@@ -139,7 +139,7 @@ internal class NotVisibleWithDestinationTest {
         val viewController = TestViewController(TestView())
         val state = NotVisibleWithDestination(
             root,
-            TestTransitionFactory(),
+            TestSceneTransitionFactory(),
             destination,
             viewController
         )

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/uistate/VisibleTest.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/uistate/VisibleTest.kt
@@ -18,7 +18,7 @@ package com.nhaarman.acorn.android.uistate
 
 import com.nhaarman.acorn.android.util.RootViewGroup
 import com.nhaarman.acorn.android.util.TestScene
-import com.nhaarman.acorn.android.util.TestTransitionFactory
+import com.nhaarman.acorn.android.util.TestSceneTransitionFactory
 import com.nhaarman.acorn.android.util.TestView
 import com.nhaarman.acorn.android.util.TestViewController
 import com.nhaarman.acorn.android.util.TestViewControllerFactory
@@ -39,7 +39,7 @@ internal class VisibleTest {
 
     val state = Visible(
         root,
-        TestTransitionFactory()
+        TestSceneTransitionFactory()
     )
 
     @BeforeEach

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/uistate/VisibleWithDestinationTest.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/uistate/VisibleWithDestinationTest.kt
@@ -20,7 +20,7 @@ import com.nhaarman.acorn.android.uistate.internal.Destination
 import com.nhaarman.acorn.android.util.RootViewGroup
 import com.nhaarman.acorn.android.util.TestScene
 import com.nhaarman.acorn.android.util.TestTransition
-import com.nhaarman.acorn.android.util.TestTransitionFactory
+import com.nhaarman.acorn.android.util.TestSceneTransitionFactory
 import com.nhaarman.acorn.android.util.TestView
 import com.nhaarman.acorn.android.util.TestViewController
 import com.nhaarman.acorn.android.util.TestViewControllerFactory
@@ -39,7 +39,7 @@ internal class VisibleWithDestinationTest {
 
     val transitionTo2 = TestTransition()
     val transition2To3 = TestTransition()
-    val transitionFactory = TestTransitionFactory()
+    val transitionFactory = TestSceneTransitionFactory()
 
     val scene = spy(TestScene())
     val sceneView = TestView()

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/util/TestSceneTransitionFactory.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/util/TestSceneTransitionFactory.kt
@@ -17,13 +17,17 @@
 package com.nhaarman.acorn.android.util
 
 import com.nhaarman.acorn.android.transition.SceneTransition
-import com.nhaarman.acorn.android.transition.TransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Scene
 
-class TestTransitionFactory : TransitionFactory {
+class TestSceneTransitionFactory : SceneTransitionFactory {
 
     val transitions = mutableMapOf<Pair<Scene<*>, Scene<*>>, SceneTransition>()
+
+    override fun supports(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Boolean {
+        return (previousScene to newScene) in transitions
+    }
 
     override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition {
         return transitions[previousScene to newScene]!!

--- a/samples/hello-concurrentpairnavigator/src/main/java/com/nhaarman/acorn/samples/helloconcurrentpairnavigator/MainActivity.kt
+++ b/samples/hello-concurrentpairnavigator/src/main/java/com/nhaarman/acorn/samples/helloconcurrentpairnavigator/MainActivity.kt
@@ -19,8 +19,8 @@ package com.nhaarman.acorn.samples.helloconcurrentpairnavigator
 import com.nhaarman.acorn.android.AcornAppCompatActivity
 import com.nhaarman.acorn.android.navigation.NavigatorProvider
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.TransitionFactory
-import com.nhaarman.acorn.android.transition.transitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
+import com.nhaarman.acorn.android.transition.sceneTransitionFactory
 import com.nhaarman.acorn.presentation.SceneKey
 
 class MainActivity : AcornAppCompatActivity() {
@@ -33,8 +33,8 @@ class MainActivity : AcornAppCompatActivity() {
         return HelloConcurrentPairNavigatorViewControllerFactory()
     }
 
-    override fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): TransitionFactory {
-        return transitionFactory(viewControllerFactory) {
+    override fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): SceneTransitionFactory {
+        return sceneTransitionFactory(viewControllerFactory) {
             (SceneKey.defaultKey<FirstScene>() to SceneKey.defaultKey<SecondScene>()) use FirstSecondTransition
             (SceneKey.defaultKey<SecondScene>() to SceneKey.defaultKey<FirstScene>()) use SecondFirstTransition
         }

--- a/samples/hello-transitionanimation/src/main/java/com/nhaarman/acorn/samples/hellotransitionanimation/MainActivity.kt
+++ b/samples/hello-transitionanimation/src/main/java/com/nhaarman/acorn/samples/hellotransitionanimation/MainActivity.kt
@@ -19,8 +19,8 @@ package com.nhaarman.acorn.samples.hellotransitionanimation
 import com.nhaarman.acorn.android.AcornAppCompatActivity
 import com.nhaarman.acorn.android.navigation.NavigatorProvider
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.TransitionFactory
-import com.nhaarman.acorn.android.transition.transitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
+import com.nhaarman.acorn.android.transition.sceneTransitionFactory
 
 class MainActivity : AcornAppCompatActivity() {
 
@@ -28,8 +28,8 @@ class MainActivity : AcornAppCompatActivity() {
         return HelloTransitionAnimationNavigatorProvider
     }
 
-    override fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): TransitionFactory {
-        return transitionFactory(viewControllerFactory) {
+    override fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): SceneTransitionFactory {
+        return sceneTransitionFactory(viewControllerFactory) {
             (FirstScene::class to SecondScene::class) use FirstToSecondTransition
         }
     }

--- a/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/MainActivity.kt
+++ b/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/MainActivity.kt
@@ -19,7 +19,7 @@ package com.nhaarman.acorn.notesapp.android
 import com.nhaarman.acorn.android.AcornAppCompatActivity
 import com.nhaarman.acorn.android.navigation.NavigatorProvider
 import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.TransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.notesapp.android.TransitionFactoryProvider.transitionFactory
 import com.nhaarman.acorn.notesapp.android.ViewFactoryProvider.viewFactory
 
@@ -33,7 +33,7 @@ class MainActivity : AcornAppCompatActivity() {
         return viewFactory
     }
 
-    override fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): TransitionFactory {
+    override fun provideTransitionFactory(viewControllerFactory: ViewControllerFactory): SceneTransitionFactory {
         return transitionFactory
     }
 }

--- a/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/TransitionFactoryProvider.kt
+++ b/samples/notes-app/android/src/main/java/com/nhaarman/acorn/notesapp/android/TransitionFactoryProvider.kt
@@ -17,9 +17,9 @@
 package com.nhaarman.acorn.notesapp.android
 
 import com.nhaarman.acorn.android.transition.FadeOutToBottomTransition
-import com.nhaarman.acorn.android.transition.TransitionFactory
+import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.android.transition.hideKeyboardOnStart
-import com.nhaarman.acorn.android.transition.transitionFactory
+import com.nhaarman.acorn.android.transition.sceneTransitionFactory
 import com.nhaarman.acorn.notesapp.android.ui.transition.EditItemItemListTransition
 import com.nhaarman.acorn.notesapp.android.ui.transition.ItemListCreateItemTransition
 import com.nhaarman.acorn.notesapp.android.ui.transition.ItemListEditItemTransition
@@ -29,8 +29,8 @@ import com.nhaarman.acorn.notesapp.presentation.itemlist.ItemListScene
 
 object TransitionFactoryProvider {
 
-    val transitionFactory: TransitionFactory by lazy {
-        transitionFactory(ViewFactoryProvider.viewFactory) {
+    val transitionFactory: SceneTransitionFactory by lazy {
+        sceneTransitionFactory(ViewFactoryProvider.viewFactory) {
             (ItemListScene::class to CreateItemScene::class) use ItemListCreateItemTransition
 
             (ItemListScene::class to EditItemScene::class) use ItemListEditItemTransition


### PR DESCRIPTION
This allows for easy composition of factories. The
default factory will still be the fallback type, so
there is always an implementation available.