### PR TITLE
Don't use replay(1) to cache View references

### DIFF
--- a/ext/acorn/acorn-rx/src/test/java/com/nhaarman/acorn/presentation/RxSceneTest.kt
+++ b/ext/acorn/acorn-rx/src/test/java/com/nhaarman/acorn/presentation/RxSceneTest.kt
@@ -52,6 +52,18 @@ class RxSceneTest {
     }
 
     @Test
+    fun `subscribing after view attach`() {
+        /* Given */
+        scene.attach(testView)
+
+        /* When */
+        val observer = scene.viewObservable.test()
+
+        /* Then */
+        expect(observer.lastValue).toBe(Option.just(testView))
+    }
+
+    @Test
     fun `detaching a view notifies observers`() {
         /* Given */
         val observer = scene.viewObservable.test()


### PR DESCRIPTION
The `replay` operator internally caches N+1 elements instead of just
N, meaning it will keep a strong reference to the previous emitted
element. When this element references an Activity, leaks occur.

See https://github.com/ReactiveX/RxJava/issues/6475.