### PR TITLE
Remove fallback from BindingSceneTransitionFactory

### DIFF
--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/ComposingSceneTransitionFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/ComposingSceneTransitionFactory.kt
@@ -16,6 +16,7 @@
 
 package com.nhaarman.acorn.android.transition
 
+import com.nhaarman.acorn.android.transition.internal.TransitionCreationFailure
 import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Scene
 
@@ -32,8 +33,9 @@ class ComposingSceneTransitionFactory private constructor(
 
     override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition {
         return sources
-            .first { it.supports(previousScene, newScene, data) }
-            .transitionFor(previousScene, newScene, data)
+            .firstOrNull { it.supports(previousScene, newScene, data) }
+            ?.transitionFor(previousScene, newScene, data)
+            ?: throw TransitionCreationFailure(previousScene, newScene)
     }
 
     companion object {

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/TransitionFactoryDSL.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/TransitionFactoryDSL.kt
@@ -32,22 +32,32 @@ import kotlin.reflect.KClass
  * @see [SceneTransitionFactoryBuilder]
  */
 fun sceneTransitionFactory(
+    init: SceneTransitionFactoryBuilder.() -> Unit
+): SceneTransitionFactory {
+    return SceneTransitionFactoryBuilder().apply(init).build()
+}
+
+/**
+ * Entry point for the [SceneTransitionFactory] DSL.
+ *
+ * @see [SceneTransitionFactoryBuilder]
+ */
+@Deprecated(
+    "Use sceneTransitionFactory(SceneTransitionFactoryBuilder.() -> Unit) instead",
+    ReplaceWith("sceneTransitionFactory(init)")
+)
+fun sceneTransitionFactory(
     viewControllerFactory: ViewControllerFactory,
     init: SceneTransitionFactoryBuilder.() -> Unit
 ): SceneTransitionFactory {
-    return SceneTransitionFactoryBuilder(viewControllerFactory).apply(init).build()
+    return sceneTransitionFactory(init)
 }
 
 /**
  * A DSL that can create [SceneTransitionFactory] instances by binding pairs of Scenes
  * to [SceneTransition] instances.
- *
- * @param viewControllerFactory The [ViewControllerFactory] instance to use for
- * layout inflation for fallback transition animations.
  */
-class SceneTransitionFactoryBuilder internal constructor(
-    private val viewControllerFactory: ViewControllerFactory
-) {
+class SceneTransitionFactoryBuilder {
 
     private val bindings = mutableListOf<TransitionBinding>()
 
@@ -77,9 +87,6 @@ class SceneTransitionFactoryBuilder internal constructor(
     }
 
     fun build(): SceneTransitionFactory {
-        return BindingSceneTransitionFactory(
-            viewControllerFactory,
-            bindings.asSequence()
-        )
+        return BindingSceneTransitionFactory(bindings.asSequence())
     }
 }

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/BindingSceneTransitionFactory.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/BindingSceneTransitionFactory.kt
@@ -16,28 +16,24 @@
 
 package com.nhaarman.acorn.android.transition.internal
 
-import com.nhaarman.acorn.android.presentation.ViewControllerFactory
-import com.nhaarman.acorn.android.transition.DefaultSceneTransitionFactory
 import com.nhaarman.acorn.android.transition.SceneTransition
 import com.nhaarman.acorn.android.transition.SceneTransitionFactory
 import com.nhaarman.acorn.navigation.TransitionData
 import com.nhaarman.acorn.presentation.Scene
 
 internal class BindingSceneTransitionFactory(
-    private val viewControllerFactory: ViewControllerFactory,
     private val bindings: Sequence<TransitionBinding>
 ) : SceneTransitionFactory {
 
-    private val delegate by lazy { DefaultSceneTransitionFactory(viewControllerFactory) }
-
     override fun supports(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Boolean {
-        return true
+        return bindings
+            .any { it.transitionFor(previousScene, newScene, data) != null }
     }
 
     override fun transitionFor(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): SceneTransition {
         return bindings
             .mapNotNull { it.transitionFor(previousScene, newScene, data) }
             .firstOrNull()
-            ?: delegate.transitionFor(previousScene, newScene, data)
+            ?: throw TransitionCreationFailure(previousScene, newScene)
     }
 }

--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/TransitionCreationFailure.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/transition/internal/TransitionCreationFailure.kt
@@ -1,0 +1,28 @@
+/*
+ *    Copyright 2018 Niek Haarman
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.nhaarman.acorn.android.transition.internal
+
+import com.nhaarman.acorn.presentation.Scene
+
+internal class TransitionCreationFailure(
+    private val previousScene: Scene<*>,
+    private val newScene: Scene<*>
+) : RuntimeException() {
+
+    override val message: String?
+        get() = "Could not create transition from $previousScene to $newScene."
+}

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/transition/ComposingSceneTransitionFactoryTest.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/transition/ComposingSceneTransitionFactoryTest.kt
@@ -1,0 +1,190 @@
+/*
+ *    Copyright 2018 Niek Haarman
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.nhaarman.acorn.android.transition
+
+import com.nhaarman.acorn.android.util.TestScene
+import com.nhaarman.acorn.android.util.TestTransition
+import com.nhaarman.acorn.navigation.TransitionData
+import com.nhaarman.acorn.presentation.Scene
+import com.nhaarman.acorn.presentation.SceneKey
+import com.nhaarman.expect.expect
+import com.nhaarman.expect.expectErrorWithMessage
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class ComposingSceneTransitionFactoryTest {
+
+    private val scene1 = TestScene(SceneKey("1"))
+    private val scene2 = TestScene(SceneKey("2"))
+    private val scene3 = TestScene(SceneKey("3"))
+
+    private val transition1 = TestTransition()
+    private val transition2 = TestTransition()
+
+    private val transitionFactory12 = TestSceneTransitionFactory(scene1, scene2, transition1)
+    private val transitionFactory23 = TestSceneTransitionFactory(scene2, scene3, transition2)
+
+    @Test
+    fun `no sources results in false for supports call`() {
+        /* Given */
+        val factory = ComposingSceneTransitionFactory.from(emptyList())
+
+        /* When */
+        val result = factory.supports(scene1, scene2, null)
+
+        /* Then */
+        expect(result).toBe(false)
+    }
+
+    @Test
+    fun `no sources results in exception for transition call`() {
+        /* Given */
+        val factory = ComposingSceneTransitionFactory.from(emptyList())
+
+        /* Expect */
+        expectErrorWithMessage("Could not create transition") on {
+
+            /* When */
+            factory.transitionFor(scene1, scene2, null)
+        }
+    }
+
+    @Test
+    fun `single source with matching transition supports true`() {
+        /* Given */
+        val factory = ComposingSceneTransitionFactory.from(
+            transitionFactory12
+        )
+
+        /* When */
+        val result = factory.supports(scene1, scene2, null)
+
+        /* Then */
+        expect(result).toBe(true)
+    }
+
+    @Test
+    fun `single source with matching transition results in proper transition`() {
+        /* Given */
+        val factory = ComposingSceneTransitionFactory.from(
+            transitionFactory12
+        )
+
+        /* When */
+        val result = factory.transitionFor(scene1, scene2, null)
+
+        /* Then */
+        expect(result).toBe(transition1)
+    }
+
+    @Test
+    fun `single source with non matching transition supports false`() {
+        /* Given */
+        val factory = ComposingSceneTransitionFactory.from(
+            transitionFactory12
+        )
+
+        /* When */
+        val result = factory.supports(scene1, scene3, null)
+
+        /* Then */
+        expect(result).toBe(false)
+    }
+
+    @Test
+    fun `single source with non matching transition results in exception`() {
+        /* Given */
+        val factory = ComposingSceneTransitionFactory.from(
+            transitionFactory12
+        )
+
+        /* Expect */
+        expectErrorWithMessage("Could not create transition") on {
+
+            /* When */
+            factory.transitionFor(scene1, scene3, null)
+        }
+    }
+
+    @Test
+    fun `two sources with matching transition in second supports true`() {
+        /* Given */
+        val factory = ComposingSceneTransitionFactory.from(
+            transitionFactory12,
+            transitionFactory23
+        )
+
+        /* When */
+        val result = factory.supports(scene2, scene3, null)
+
+        /* Then */
+        expect(result).toBe(true)
+    }
+
+    @Test
+    fun `single source with matching transition in second results in proper transition`() {
+        /* Given */
+        val factory = ComposingSceneTransitionFactory.from(
+            transitionFactory12,
+            transitionFactory23
+        )
+
+        /* When */
+        val result = factory.transitionFor(scene2, scene3, null)
+
+        /* Then */
+        expect(result).toBe(transition2)
+    }
+
+    @Nested
+    inner class `issue 139` {
+
+        @Test
+        fun `a binding factory in a composing factory does not block second factory`() {
+            /* Given */
+            val factory = ComposingSceneTransitionFactory.from(
+                sceneTransitionFactory { },
+                transitionFactory12
+            )
+
+            /* When */
+            val result = factory.transitionFor(scene1, scene2, null)
+
+            /* Then */
+            expect(result).toBe(transition1)
+        }
+    }
+
+    private class TestSceneTransitionFactory(
+        private val fromScene: Scene<*>,
+        private val toScene: Scene<*>,
+        private val transition: SceneTransition
+    ) : SceneTransitionFactory {
+
+        override fun supports(previousScene: Scene<*>, newScene: Scene<*>, data: TransitionData?): Boolean {
+            return previousScene == fromScene && newScene == toScene
+        }
+
+        override fun transitionFor(
+            previousScene: Scene<*>,
+            newScene: Scene<*>,
+            data: TransitionData?
+        ): SceneTransition {
+            return transition
+        }
+    }
+}

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/transition/internal/BindingSceneTransitionFactoryTest.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/transition/internal/BindingSceneTransitionFactoryTest.kt
@@ -1,0 +1,119 @@
+/*
+ *    Copyright 2018 Niek Haarman
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.nhaarman.acorn.android.transition.internal
+
+import com.nhaarman.acorn.android.transition.SceneTransition
+import com.nhaarman.acorn.android.util.TestScene
+import com.nhaarman.acorn.presentation.SceneKey
+import com.nhaarman.expect.expect
+import com.nhaarman.expect.expectErrorWithMessage
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.jupiter.api.Test
+
+internal class BindingSceneTransitionFactoryTest {
+
+    private val scene1 = TestScene(SceneKey("1"))
+    private val scene2 = TestScene(SceneKey("2"))
+    private val scene3 = TestScene(SceneKey("3"))
+
+    private val transition1 = mock<SceneTransition>()
+
+    @Test
+    fun `factory without bindings supports no transition`() {
+        /* Given */
+        val factory = BindingSceneTransitionFactory(bindings = emptySequence())
+
+        /* When */
+        val result = factory.supports(scene1, scene2, null)
+
+        /* Then */
+        expect(result).toBe(false)
+    }
+
+    @Test
+    fun `requesting transition without bindings throws error`() {
+        /* Given */
+        val factory = BindingSceneTransitionFactory(bindings = emptySequence())
+
+        /* Expect */
+        expectErrorWithMessage("Could not create transition") on {
+
+            /* When */
+            factory.transitionFor(mock(), mock(), null)
+        }
+    }
+
+    @Test
+    fun `factory with single binding supports that transition`() {
+        /* Given */
+        val factory = BindingSceneTransitionFactory(
+            bindings = sequenceOf(
+                KeyBinding(
+                    scene1.key,
+                    scene2.key,
+                    transition1
+                )
+            )
+        )
+
+        /* When */
+        val result = factory.supports(scene1, scene2, null)
+
+        /* Then */
+        expect(result).toBe(true)
+    }
+
+    @Test
+    fun `factory with single binding returns proper transition`() {
+        /* Given */
+        val factory = BindingSceneTransitionFactory(
+            bindings = sequenceOf(
+                KeyBinding(
+                    scene1.key,
+                    scene2.key,
+                    transition1
+                )
+            )
+        )
+
+        /* When */
+        val result = factory.transitionFor(scene1, scene2, null)
+
+        /* Then */
+        expect(result).toBe(transition1)
+    }
+
+    @Test
+    fun `factory with single binding doesn't support other transition`() {
+        /* Given */
+        val factory = BindingSceneTransitionFactory(
+            bindings = sequenceOf(
+                KeyBinding(
+                    scene1.key,
+                    scene2.key,
+                    transition1
+                )
+            )
+        )
+
+        /* When */
+        val result = factory.supports(scene2, scene3, null)
+
+        /* Then */
+        expect(result).toBe(false)
+    }
+}


### PR DESCRIPTION
With the introduction of `supports`, this fallback strategy
has become obsolete, in favor of an explicit fallback
factory that is placed last in the
ComposingSceneTransitionFactory.

Fixes #139 