### PR TITLE
Save references to scene and activity controller

### DIFF
--- a/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/internal/DefaultActivityHandler.kt
+++ b/ext/acorn-android/src/main/java/com/nhaarman/acorn/android/dispatching/internal/DefaultActivityHandler.kt
@@ -50,6 +50,9 @@ internal class DefaultActivityHandler(
                 "ActivityHandler",
                 "New external Scene has the same key as the previously dispatched Scene, not starting Activity."
             )
+
+            lastScene = scene
+            lastActivityController = activityController
             return
         }
 

--- a/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/dispatching/internal/DefaultActivityHandlerTest.kt
+++ b/ext/acorn-android/src/test/java/com/nhaarman/acorn/android/dispatching/internal/DefaultActivityHandlerTest.kt
@@ -214,6 +214,34 @@ internal class DefaultActivityHandlerTest {
                 verify(scene).detach(activityController)
             }
         }
+
+        @Nested
+        inner class ResultsWithSavedState {
+
+            private val activityHandler by lazy {
+                val original = DefaultActivityHandler(mock(), null)
+                original.withScene(scene, activityController)
+                val state = original.saveInstanceState()
+                DefaultActivityHandler(callback, state)
+            }
+
+            @Test
+            // https://github.com/nhaarman/acorn/issues/165
+            fun `onActivityResult notifies activityController for restored state`() {
+                /* Given */
+                activityHandler.withScene(scene, activityController)
+
+                /* When */
+                activityHandler.onActivityResult(3, null)
+
+                /* Then */
+                inOrder(scene, activityController) {
+                    verify(scene).attach(activityController)
+                    verify(activityController).onResult(3, null)
+                    verify(scene).detach(activityController)
+                }
+            }
+        }
     }
 
     private class TestActivityController(private val intent: Intent) : ActivityController {

--- a/samples/hello-startactivity/src/androidTest/java/com/nhaarman/acorn/samples/hellostartactivity/AppTest.kt
+++ b/samples/hello-startactivity/src/androidTest/java/com/nhaarman/acorn/samples/hellostartactivity/AppTest.kt
@@ -17,6 +17,10 @@
 package com.nhaarman.acorn.samples.hellostartactivity
 
 import android.content.Intent
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -50,6 +54,7 @@ class AppTest {
         exitMaps()
 
         expect(device.currentPackageName).toBe(appPackage)
+        onView(withText("START MAPS")).check(matches(isDisplayed()))
     }
 
     @Test
@@ -69,6 +74,7 @@ class AppTest {
         exitMaps()
 
         expect(device.currentPackageName).toBe(appPackage)
+        onView(withText("START MAPS")).check(matches(isDisplayed()))
     }
 
     @Test
@@ -88,6 +94,7 @@ class AppTest {
         exitMaps()
 
         expect(device.currentPackageName).toBe(appPackage)
+        onView(withText("START MAPS")).check(matches(isDisplayed()))
     }
 
     @After


### PR DESCRIPTION
When the ActivityHandler is restored from a saved
state, the references to the Scene and ActivityController
are lost. A call to `onActivityResult()` will then
fail because there is no reference to the ActivityController.

Fixes #165 