### PR TITLE
Invoke Scene.onStart after listener notification for StackNavigator

### DIFF
--- a/ext/acorn/src/main/java/com/nhaarman/acorn/navigation/StackNavigator.kt
+++ b/ext/acorn/src/main/java/com/nhaarman/acorn/navigation/StackNavigator.kt
@@ -277,8 +277,9 @@ abstract class StackNavigator(
 
             override fun start(): StateTransition {
                 return StateTransition(Active(scenes, listeners)) {
-                    scenes.last().onStart()
+                    // These lines should be swapped
                     listeners.forEach { it.scene(scenes.last(), null) }
+                    scenes.last().onStart()
                 }
             }
 

--- a/ext/acorn/src/test/java/com/nhaarman/acorn/navigation/StackNavigatorTest.kt
+++ b/ext/acorn/src/test/java/com/nhaarman/acorn/navigation/StackNavigatorTest.kt
@@ -1292,6 +1292,21 @@ internal class StackNavigatorTest {
                 verify(scene1).onStart()
             }
         }
+
+        @Test
+        fun `starting the navigator invokes listeners before starting the scene`() {
+            /* Given */
+            navigator.addNavigatorEventsListener(listener)
+
+            /* When */
+            navigator.onStart()
+
+            /* Then */
+            inOrder(listener, scene1) {
+                verify(listener).scene(eq(scene1), anyOrNull())
+                verify(scene1).onStart()
+            }
+        }
     }
 
     class TestStackNavigator(


### PR DESCRIPTION
This fix was already applied for a started Navigator, but now
it is also applied when _starting_ the navigator.