### PR TITLE
Invoke Scene.onStart after listener notification for ReplacingNavigator

### DIFF
--- a/ext/acorn/src/main/java/com/nhaarman/acorn/navigation/ReplacingNavigator.kt
+++ b/ext/acorn/src/main/java/com/nhaarman/acorn/navigation/ReplacingNavigator.kt
@@ -222,8 +222,8 @@ abstract class ReplacingNavigator(
 
             override fun start(): StateTransition {
                 return StateTransition(Active(scene, listeners)) {
-                    scene.onStart()
                     listeners.forEach { it.scene(scene) }
+                    scene.onStart()
                 }
             }
 

--- a/ext/acorn/src/main/java/com/nhaarman/acorn/navigation/StackNavigator.kt
+++ b/ext/acorn/src/main/java/com/nhaarman/acorn/navigation/StackNavigator.kt
@@ -277,7 +277,6 @@ abstract class StackNavigator(
 
             override fun start(): StateTransition {
                 return StateTransition(Active(scenes, listeners)) {
-                    // These lines should be swapped
                     listeners.forEach { it.scene(scenes.last(), null) }
                     scenes.last().onStart()
                 }

--- a/ext/acorn/src/test/java/com/nhaarman/acorn/navigation/ReplacingNavigatorTest.kt
+++ b/ext/acorn/src/test/java/com/nhaarman/acorn/navigation/ReplacingNavigatorTest.kt
@@ -699,6 +699,21 @@ internal class ReplacingNavigatorTest {
                 verify(scene1).onStart()
             }
         }
+
+        @Test
+        fun `starting the navigator invokes listeners before starting the scene`() {
+            /* Given */
+            navigator.addNavigatorEventsListener(listener)
+
+            /* When */
+            navigator.onStart()
+
+            /* Then */
+            inOrder(listener, initialScene) {
+                verify(listener).scene(eq(initialScene), anyOrNull())
+                verify(initialScene).onStart()
+            }
+        }
     }
 
     private open class TestListener : Navigator.Events {


### PR DESCRIPTION
This fix was already applied for a started Navigator, but now
it is also applied when _starting_ the navigator.